### PR TITLE
Updated README.md to reflect that copying multiple files is required.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Features
 
 Installation
 --------
-1) deploy ssl_tls.py to ./scapy/layers
+1) copy all files inside src/scapy/layers to ./scapy/layers
 
 2) modify ./scapy/config.py to autoload this new layer
 ```diff


### PR DESCRIPTION
Hi, I think there should be a line mentioning the multiple files inside the layers/ folder, since earlier versions of scapy don't warn about the missing ssl_tls_crypto.py .