### PR TITLE
building SSL layer fixed. Fixes issue #5.

### DIFF
--- a/src/scapy/layers/ssl_tls.py
+++ b/src/scapy/layers/ssl_tls.py
@@ -731,11 +731,13 @@ class SSL(Packet):
                     break
                 record = cls(s[pos:pos + layer_len])
                 pos += layer_len
-                # print pos,len(s)
+                # to make 'records' appear in 'fields' it must
+                # be assigned once before appending
+                if 'records' not in self.fields:
+                    self.records = []
                 self.records.append(record)
-        except Exception, e:
+        except TypeError, e:
             pass
-            # raise e
         return s[pos:]
 
 


### PR DESCRIPTION
When adding the TLSRecords via `.append()` they are not registered in the `fields` attribute.
Once an empty list is assigned it appears in the `fields`. As the SSL layer should contain at least one record one could probably just do it once before the loop.
Might also be more efficient to just `self.fields.append('records')` but as i'm not sure what mechanism adds the item to the list and what else it might do i left it this way.