### PR TITLE
Fixed dissection of stacked TLS records

### DIFF
--- a/src/scapy/layers/ssl_tls.py
+++ b/src/scapy/layers/ssl_tls.py
@@ -796,14 +796,9 @@ def to_packet(layers):
             pkt /= layer
     except IndexError:
         pass
-    return pkt
-
-def tls_handshake_handler(pkt, tls_ctx, client):
-    if pkt.haslayer(TLSFinished):
-        return (0x16, tls_ctx.get_verify_data())
-
+    return pkt
 cleartext_handler = { TLSPlaintext: lambda pkt, tls_ctx, client: (0x17, pkt.data),
-                      TLSHandshake: tls_handshake_handler,
+                      TLSFinished: lambda pkt, tls_ctx, client: (0x16, str(TLSHandshake(type=0x14)/tls_ctx.get_verify_data())),
                       TLSChangeCipherSpec: lambda pkt, tls_ctx, client: (0x14, str(pkt)),
                       TLSAlert: lambda pkt, tls_ctx, client: (0x15, str(pkt)) }
 

--- a/src/scapy/layers/ssl_tls_crypto.py
+++ b/src/scapy/layers/ssl_tls_crypto.py
@@ -344,9 +344,9 @@ class TLSSessionCtx(object):
             label = TLSPRF.TLS_MD_SERVER_FINISH_CONST
         verify_data = []
         for pkt in self.packets.history:
-            # Assume one record per packet for now, we're missing logic to handle these cases
-            if pkt.haslayer(tls.TLSHandshake) and not pkt.haslayer(tls.TLSFinished) and not pkt.haslayer(tls.TLSHelloRequest):
-                verify_data.append(str(pkt[tls.TLSHandshake]))
+            for handshake in tls.get_all_tls_handshakes(pkt):
+                if not handshake.haslayer(tls.TLSFinished) and not handshake.haslayer(tls.TLSHelloRequest):
+                    verify_data.append(str(handshake))
 
         prf_verify_data = self.crypto.session.prf.prf_numbytes(self.crypto.session.master_secret,
                                                                label,

--- a/src/test/scapy/layers/test_ssl_tls.py
+++ b/src/test/scapy/layers/test_ssl_tls.py
@@ -1,11 +1,106 @@
-#! -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 
+import binascii
 import unittest
 import ssl_tls as tls
 import ssl_tls_crypto as tlsc
 
 from Crypto.Cipher import PKCS1_v1_5
 from Crypto.PublicKey import RSA
+from scapy.layers.inet import IP, TCP
+
+
+class TestTLSRecord(unittest.TestCase):
+
+    def setUp(self):
+        self.server_hello = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSServerHello()
+        self.cert_list = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSCertificateList()
+        self.server_hello_done = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSServerHelloDone()
+        self.stacked_pkt = self.server_hello/self.cert_list/self.server_hello_done
+        unittest.TestCase.setUp(self)
+
+    def test_stacked_tls_records_length_are_correct(self):
+        # Highlights issue https://github.com/tintinweb/scapy-ssl_tls/issues/12
+        # Before I try and fix it
+        pkt = tls.TLS(str(self.stacked_pkt))
+        self.assertEqual(len(str(self.server_hello)) - len(tls.TLSRecord()), pkt[tls.TLSRecord].length)
+
+    def test_when_stripped_only_current_record_remains(self):
+        record = self.stacked_pkt[tls.TLSRecord].rstrip()
+        self.assertEqual(record, self.server_hello)
+
+    def test_next_record_is_returned_upon_iteration(self):
+        cert_list = self.stacked_pkt[tls.TLSRecord].upper()
+        self.assertEqual(self.cert_list, cert_list.rstrip())
+        self.assertEqual(self.server_hello_done, cert_list.upper())
+
+class TestSSLDissector(unittest.TestCase):
+
+    def setUp(self):
+        self.payload = binascii.unhexlify("160301004a02000046030155514d08929c06119d291bae09ec50ba48f52069c840673c76721aa5c53bc352202de1c20c707ba9b083282d2eba3d95bdfb5847eb9241f252173a04c9f990d508002f0016030104080b0004040004010003fe308203fa308202e2a003020102020900980ceed2480234b2300d06092a864886f70d0101050500305b310b3009060355040613025553311330110603550408130a43616c69666f726e696131173015060355040a130e4369747269782053797374656d73311e301c06035504031315616d73736c2e656e672e636974726974652e6e6574301e170d3135303432343233313435395a170d3235303432313233313435395a305b310b3009060355040613025553311330110603550408130a43616c69666f726e696131173015060355040a130e4369747269782053797374656d73311e301c06035504031315616d73736c2e656e672e636974726974652e6e657430820122300d06092a864886f70d01010105000382010f003082010a0282010100c0e2f8d4d4423ef7ce3e6ea789ad83c831fd679a8745bfe7d3628a544b7f04fec8bb8eb72737a6334764b68e796fbd70f19a1754776aba2f5d9685f2931b57456825ca75baca540c34de26115037d76d1a6fabbab6cd666af98fcb6b9c2fc714fd523828babae067f9ad7da51100306b4a5783a1402a4d80524dc14d0867f526e055dbd32e6f9f785072d72b8c36994bb56c2cdbf74e2149e7c625fed1c6405e205289c2b4608bd28704303764227f4540b95054c115be9185223b8a815462818090c6c933ce4c39d4049197106fe84918048adfd185fc7d64167804ccafbae8b84dc81d0288f4078c736a4ccc04c27184ffb45b14b4bd79ab472dba8877c20f0203010001a381c03081bd301d0603551d0e041604141979840d258e11dad71d942fe77e567fc0bbb48430818d0603551d2304818530818280141979840d258e11dad71d942fe77e567fc0bbb484a15fa45d305b310b3009060355040613025553311330110603550408130a43616c69666f726e696131173015060355040a130e4369747269782053797374656d73311e301c06035504031315616d73736c2e656e672e636974726974652e6e6574820900980ceed2480234b2300c0603551d13040530030101ff300d06092a864886f70d010105050003820101006fbd05d20b74d33b727fb2ccfebf3f36950278631bf87e77f503ce8e9a080925b6276f32218cadd0a43d40d89ba0e5fd9897ac536a079440385ba59e2593100df52224a8f8b786561466558d435d9ea5e4f320028ee7afa005f09b64b16f3e6b787af31b28d623edd480a50dd64fc6f0da0eab0c38c5d8965504c9c3d5c2c85514b7b1f8df9ee2d9116ac05781dbef26a66e98679f84b0378a1f8857f69e72cf72c11e836e0144153bd412dcfb506ed9e4a6181208b92be3ba9ec13f3c5b19eb700884e04a051603f2f2302d542e094afcce6694c5e46452a486b9ba339578e0f530f98824872eef62a23d685e9710c47362a034b699b7f9e1521b135e1e950d16030100040e000000")
+        unittest.TestCase.setUp(self)
+
+    def test_stacked_tls_records_are_correctly_dissected_from_bytes(self):
+        # This is tls.TLSRecord()/tls.TLSHandshake()/tls.TLSServerHello()/tls.TLSRecord()/tls.TLSHandshake()/tls.TLSCertificateList()/tls.TLSRecord()/tls.TLSHandshake()/tls.TLSServerHelloDone()
+        # Grabbed from the wire, with hardcoded parameters
+        pkt = tls.TLS(self.payload).records
+        self.assertEqual(pkt[0][tls.TLSRecord].length, 0x4a)
+        self.assertEqual(pkt[0][tls.TLSHandshake].length, 0x46)
+        self.assertEqual(pkt[0].gmt_unix_time, 1431391496)
+        self.assertEqual(pkt[0].session_id, binascii.unhexlify("2de1c20c707ba9b083282d2eba3d95bdfb5847eb9241f252173a04c9f990d508"))
+        self.assertEqual(pkt[0].cipher_suite, tls.TLSCipherSuite.RSA_WITH_AES_128_CBC_SHA)
+        self.assertEqual(pkt[0].compression_method, tls.TLSCompressionMethod.NULL)
+        self.assertEqual(pkt[1].length, 0x408)
+        self.assertEqual(pkt[1][tls.TLSHandshake].length, 0x404)
+        self.assertEqual(pkt[1][tls.TLSCertificateList].length, 0x401)
+        self.assertEqual(pkt[2][tls.TLSRecord].length, 0x4)
+        self.assertEqual(pkt[2][tls.TLSHandshake].type, 0x0e)
+
+    def test_stacked_tls_records_are_correctly_dissected_from_bytes_using_record_functions(self):
+        pkt = tls.TLS(self.payload).to_packet()
+        self.assertEqual(pkt[tls.TLSRecord].length, 0x4a)
+        self.assertEqual(pkt[tls.TLSHandshake].length, 0x46)
+        self.assertEqual(pkt[tls.TLSServerHello].gmt_unix_time, 1431391496)
+        self.assertEqual(pkt[tls.TLSServerHello].session_id, binascii.unhexlify("2de1c20c707ba9b083282d2eba3d95bdfb5847eb9241f252173a04c9f990d508"))
+        self.assertEqual(pkt[tls.TLSServerHello].cipher_suite, tls.TLSCipherSuite.RSA_WITH_AES_128_CBC_SHA)
+        self.assertEqual(pkt[tls.TLSServerHello].compression_method, tls.TLSCompressionMethod.NULL)
+        next_record = pkt[tls.TLSRecord].upper()
+        self.assertEqual(next_record.length, 0x408)
+        self.assertEqual(next_record[tls.TLSHandshake].length, 0x404)
+        self.assertEqual(next_record[tls.TLSCertificateList].length, 0x401)
+        next_record = next_record.upper().rstrip()
+        self.assertEqual(next_record[tls.TLSRecord].length, 0x4)
+        self.assertEqual(next_record[tls.TLSHandshake].type, 0x0e)
+
+class TestTopLevelFunctions(unittest.TestCase):
+
+    def setUp(self):
+        self.server_hello = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSServerHello()
+        self.cert_list = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSCertificateList()
+        self.server_hello_done = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSServerHelloDone()
+        self.stacked_pkt = self.server_hello/self.cert_list/self.server_hello_done
+        unittest.TestCase.setUp(self)
+
+    def test_correct_number_of_identical_layers_are_reported(self):
+        self.assertEqual(tls.num_type_layers(self.stacked_pkt, tls.TLSRecord), 3)
+        self.assertEqual(tls.num_type_layers(self.stacked_pkt, tls.TLSHandshake), 3)
+        self.assertEqual(tls.num_type_layers(self.stacked_pkt, tls.TLSServerHello), 1)
+
+    def test_all_records_are_returned_on_iteration(self):
+        records = list(tls.get_all_tls_records(self.stacked_pkt))
+        self.assertEqual(records[0], self.server_hello)
+        self.assertEqual(records[1], self.cert_list)
+        self.assertEqual(records[2], self.server_hello_done)
+
+    def test_leading_layers_are_ignored_from_record_list(self):
+        pkt = IP()/TCP()/self.server_hello
+        records = list(tls.get_all_tls_records(pkt))
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0], self.server_hello)
+
+    def test_all_layers_are_returned_upon_iteration(self):
+        layers = list(tls.get_individual_layers(self.stacked_pkt))
+        self.assertEqual(len(layers), 9)
 
 class TestToRaw(unittest.TestCase):
 

--- a/src/test/scapy/layers/test_ssl_tls_crypto.py
+++ b/src/test/scapy/layers/test_ssl_tls_crypto.py
@@ -140,14 +140,14 @@ xVgf/Neb/avXgIgi6drj8dp1fWA=
         self.assertEqual(tls_ctx.crypto.session.premaster_secret, self.priv_key.decrypt(epms, None))
 
     def test_fixed_crypto_data_matches_verify_data(self):
-        verify_data = "d948eac6ecac3a73d8b3c8a5"
+        verify_data = "af590baeaee95450e7522e13"
         tls_ctx = tlsc.TLSSessionCtx()
         #tls_ctx.rsa_load_keys(self.pem_priv_key)
         client_hello = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSClientHello(gmt_unix_time=1234, random_bytes="A"*28)
         tls_ctx.insert(client_hello)
         tls_ctx.crypto.session.premaster_secret = "B"*48
         epms = "C"*256
-        server_hello = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSServerHello(gmt_unix_time=1234, random_bytes="A"*28)
+        server_hello = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSServerHello(gmt_unix_time=1234, random_bytes="A"*28, session_id="")
         tls_ctx.insert(server_hello)
         client_kex = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSClientKeyExchange()/epms
         tls_ctx.insert(client_kex)


### PR DESCRIPTION
- Added helper functions to TLSRecord to help navigate records
- Simplified confusing do_dissect() function
- Added unittest coverage

This allows handling stacked TLS Records, and proper dissection of them.

Still need fixing TLSRecord length, so that generated stacked TLS records have proper lengths. Should happen in a later commit.