### PR TITLE
Added a TLSSocket proxy implementation

### DIFF
--- a/examples/full_rsa_connection_with_application_data.py
+++ b/examples/full_rsa_connection_with_application_data.py
@@ -8,70 +8,38 @@ import sys
 from scapy_ssl_tls.ssl_tls import *
 from scapy_ssl_tls.ssl_tls_crypto import *
 
-def _send(sock, pkt):
-    sock.sendall(pkt)
-
-def _recv(sock, size=8192):
-    resp = []
-    while True:
-        try:
-            data = sock.recv(size)
-            if not data:
-                break
-            resp.append(data)
-        except socket.timeout as st:
-            break
-    return "".join(resp)
-
-def tls_hello(sock, ctx):
+def tls_hello(sock):
     client_hello = TLSRecord(version="TLS_1_0")/TLSHandshake()/TLSClientHello(version="TLS_1_0", compression_methods=[0],
-                                                                              cipher_suites=(TLSCipherSuite.RSA_WITH_AES_128_CBC_SHA))
+                                                                              cipher_suites=(TLSCipherSuite.RSA_WITH_RC4_128_SHA))
+    sock.sendall(client_hello)
+    server_hello = sock.recvall()
+    server_hello.show()
 
-    try:
-        _send(sock, str(client_hello))
-        ctx.insert(client_hello)
-        server_hello = TLS(_recv(sock))
-        ctx.insert(server_hello)
-    except socket.timeout as st:
-        print("No response from peer during TLS Handshake", file=sys.stderr)
-
-def tls_client_key_exchange(sock, ctx):
-    client_key_exchange = TLSRecord()/TLSHandshake()/TLSClientKeyExchange()/ctx.get_encrypted_pms()
+def tls_client_key_exchange(sock):
+    client_key_exchange = TLSRecord()/TLSHandshake()/TLSClientKeyExchange()/sock.tls_ctx.get_encrypted_pms()
     client_ccs = TLSRecord()/TLSChangeCipherSpec()
-    client_pkt = TLS.from_records([client_key_exchange, client_ccs])
-    try:
-        ctx.insert(client_pkt)
-        _send(sock, str(client_pkt))
-        client_finished = to_raw(TLSFinished(), ctx)
-        ctx.insert(client_finished)
-        _send(sock, str(client_finished))
-        server_finished = TLS(_recv(sock), ctx=ctx)
-        ctx.insert(server_finished)
-        server_finished.show()
-    except socket.timeout as st:
-        print("No reponse from peer after TLS Finished", file=sys.stderr)
+    sock.sendall(TLS.from_records([client_key_exchange, client_ccs]))
+    sock.sendall(to_raw(TLSFinished(), sock.tls_ctx))
+    server_finished = sock.recvall()
+    server_finished.show()
 
 def tls_client(ip, priv_key=None):
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     try:
         sock.connect(ip)
-        sock.settimeout(1)
+        sock = TLSSocket(sock, client=True)
         print("Connected to server: %s" % (ip,))
     except socket.timeout as te:
         print("Failed to open connection to server: %s" % (ip,), file=sys.stderr)
     else:
-        ssl_ctx = TLSSessionCtx()
-        tls_hello(sock, ssl_ctx)
-        tls_client_key_exchange(sock, ssl_ctx)
+        tls_hello(sock)
+        tls_client_key_exchange(sock)
         print("Finished handshake. Sending application data (GET request)")
-        app_data = to_raw(TLSPlaintext(data="GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"), ssl_ctx)
-        _send(sock, str(app_data))
-        data = _recv(sock)
-        resp = TLS(data, ctx=ssl_ctx)
+        sock.sendall(to_raw(TLSPlaintext(data="GET / HTTP/1.1\r\nHOST: localhost\r\n\r\n"), sock.tls_ctx))
+        resp = sock.recvall()
         print("Got response from server")
         resp.show()
-        close_notify = to_raw(TLSAlert(level=TLSAlertLevel.WARNING, description=TLSAlertDescription.CLOSE_NOTIFY), ssl_ctx)
-        _send(sock, str(close_notify))
+        close_notify = sock.sendall(to_raw(TLSAlert(level=TLSAlertLevel.WARNING, description=TLSAlertDescription.CLOSE_NOTIFY), sock.tls_ctx))
         print("Sending close notify to tear down connection")
     finally:
         sock.close()

--- a/scapy_ssl_tls/ssl_tls.py
+++ b/scapy_ssl_tls/ssl_tls.py
@@ -548,7 +548,7 @@ class TLSDecryptablePacket(Packet):
             if self.tls_ctx.sec_params.negotiated_crypto_param["cipher"]["mode"] != None:
                 try:
                     self.padding_len = ord(raw_bytes[-1])
-                    self.padding = raw_bytes[-self.padding_len - 1:-2]
+                    self.padding = raw_bytes[-self.padding_len - 1:-1]
                     self.mac = raw_bytes[-self.padding_len - hash_size - 1:-self.padding_len - 1]
                     data = raw_bytes[:-self.padding_len - hash_size - 1]
                 except IndexError:
@@ -565,7 +565,7 @@ class TLSPlaintext(TLSDecryptablePacket):
 
 class TLSChangeCipherSpec(TLSDecryptablePacket):
     name = "TLS ChangeCipherSpec"
-    fields_desc = [ StrField("message", '\x01', fmt="H")]
+    fields_desc = [ StrField("message", '\x01', fmt="H") ]
 
 class TLSAlert(TLSDecryptablePacket):
     name = "TLS Alert"

--- a/tests/test_ssl_tls.py
+++ b/tests/test_ssl_tls.py
@@ -534,10 +534,5 @@ UM6j0ZuSMFOCr/lGPAoOQU0fskidGEHi1/kW+suSr28TqsyYZpwBDQ==
         self.assertTrue(len(ciphertext))
         self.assertEqual(ciphertext,ciphertext_2)
 
-class TestTLSSocket(unittest.TestCase):
-
-    def test_tls_context_is_created_when_not_supplied(self):
-        raise NotImplementedError("Come on... Get your sleeves up and mock socket...")
-
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ssl_tls.py
+++ b/tests/test_ssl_tls.py
@@ -3,6 +3,7 @@
 import binascii
 import os
 import re
+import socket
 import unittest
 import scapy_ssl_tls.ssl_tls as tls
 import scapy_ssl_tls.ssl_tls_crypto as tlsc
@@ -13,6 +14,7 @@ from Crypto.PublicKey import RSA
 from scapy.all import conf, rdpcap
 from scapy.layers import x509
 from scapy.layers.inet import IP, TCP
+
 
 def env_local_file(file):
     return os.path.join(os.path.dirname(__file__),'files',file)
@@ -362,7 +364,7 @@ xVgf/Neb/avXgIgi6drj8dp1fWA=
         # TLSv1.0
         self.hello_version = 0x0301
         # RSA_WITH_RC4_128_SHA
-        self.cipher_suite = 0x5
+        self.cipher_suite = 0x2f
         # NULL
         self.comp_method = 0x0
         self.client_hello = tls.TLSRecord(version=self.record_version)/tls.TLSHandshake()/tls.TLSClientHello(version=self.hello_version, compression_methods=[self.comp_method], cipher_suites=[self.cipher_suite])
@@ -531,6 +533,11 @@ UM6j0ZuSMFOCr/lGPAoOQU0fskidGEHi1/kW+suSr28TqsyYZpwBDQ==
         ciphertext_2 = ''.join(pubkey_extract_from_der.encrypt(plaintext,None))
         self.assertTrue(len(ciphertext))
         self.assertEqual(ciphertext,ciphertext_2)
+
+class TestTLSSocket(unittest.TestCase):
+
+    def test_tls_context_is_created_when_not_supplied(self):
+        raise NotImplementedError("Come on... Get your sleeves up and mock socket...")
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ssl_tls.py
+++ b/tests/test_ssl_tls.py
@@ -9,7 +9,7 @@ import scapy_ssl_tls.ssl_tls as tls
 import scapy_ssl_tls.ssl_tls_crypto as tlsc
 
 from Crypto.Cipher import PKCS1_v1_5
-from Crypto.Hash import SHA
+from Crypto.Hash import MD5, SHA
 from Crypto.PublicKey import RSA
 from scapy.all import conf, rdpcap
 from scapy.layers import x509
@@ -94,10 +94,10 @@ class TestTLSDissector(unittest.TestCase):
         tls_ctx.insert(app_response_records)
         # Test decryption against given states
         self.assertTrue(server_finished_records.haslayer(tls.TLSPlaintext))
-        self.assertEqual(server_finished_records[tls.TLSPlaintext].data, "\x14\x00\x00\x0c3\x13V\xac\x90.6\x89~7\x13\xbd")
-        self.assertEqual(server_finished_records[tls.TLSPlaintext].mac, "\xac'\x9a\x94\xf6t'\x18E\x03nD\x0b\xf4\xf7\xf5T\xce\x05q")
-        self.assertEqual(server_finished_records[tls.TLSPlaintext].padding, "\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b")
         self.assertEqual(server_finished_records[tls.TLSPlaintext].padding_len, ord("\x0b"))
+        self.assertEqual(server_finished_records[tls.TLSPlaintext].padding, "\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b")
+        self.assertEqual(server_finished_records[tls.TLSPlaintext].mac, "\xac'\x9a\x94\xf6t'\x18E\x03nD\x0b\xf4\xf7\xf5T\xce\x05q")
+        self.assertEqual(server_finished_records[tls.TLSPlaintext].data, "\x14\x00\x00\x0c3\x13V\xac\x90.6\x89~7\x13\xbd")
         self.assertTrue(app_response_records.haslayer(tls.TLSPlaintext))
         self.assertTrue(app_response_records[3][tls.TLSPlaintext].data.startswith("HTTP"))
 
@@ -123,6 +123,39 @@ class TestTLSDissector(unittest.TestCase):
         handshake = tls.TLSRecord()/tls.TLSHandshake()/"C"*5
         with self.assertRaises(ValueError):
             tls.TLS(str(handshake), ctx=tls_ctx)
+
+
+class TestTLSDecryptablePacket(unittest.TestCase):
+
+    def test_packet_does_not_contain_mac_or_padding_if_not_received_encrypted(self):
+        pkt = tls.TLSRecord()/tls.TLSChangeCipherSpec()
+        records = tls.TLS(str(pkt))
+        with self.assertRaises(AttributeError):
+            records[tls.TLSChangeCipherSpec].mac
+            records[tls.TLSChangeCipherSpec].padding
+
+    def test_session_context_is_removed_from_scapy_on_init(self):
+        pkt = tls.TLSRecord()/tls.TLSAlert()
+        records = tls.TLS(str(pkt), ctx=tlsc.TLSSessionCtx())
+        with self.assertRaises(KeyError):
+            records.fields["ctx"]
+
+    def test_streaming_mac_and_padding_are_added_if_session_context_is_provided(self):
+        data = "%s%s" % ("A"*2, "B"*MD5.digest_size)
+        tls_ctx = tlsc.TLSSessionCtx()
+        tls_ctx.sec_params = tlsc.TLSSecurityParameters(tls.TLSCipherSuite.RSA_EXPORT1024_WITH_RC4_56_MD5, "A"*48, "B"*32, "C"*32)
+        records = tls.TLSAlert(data, ctx=tls_ctx)
+        self.assertEqual("B"*MD5.digest_size, records[tls.TLSAlert].mac)
+        self.assertEqual("", records[tls.TLSAlert].padding)
+
+    def test_cbc_mac_and_padding_are_added_if_session_context_is_provided(self):
+        data = "%s%s%s" % ("A"*2, "B"*SHA.digest_size, "\x03"*4)
+        tls_ctx = tlsc.TLSSessionCtx()
+        tls_ctx.sec_params = tlsc.TLSSecurityParameters(tls.TLSCipherSuite.RSA_WITH_DES_CBC_SHA, "A"*48, "B"*32, "C"*32)
+        records = tls.TLSAlert(data, ctx=tls_ctx)
+        self.assertEqual(ord("\x03"), records[tls.TLSAlert].padding_len)
+        self.assertEqual("\x03"*3, records[tls.TLSAlert].padding)
+        self.assertEqual("B"*SHA.digest_size, records[tls.TLSAlert].mac)
 
 class TestTLSClientHello(unittest.TestCase):
     

--- a/tests/test_ssl_tls_crypto.py
+++ b/tests/test_ssl_tls_crypto.py
@@ -315,8 +315,8 @@ xVgf/Neb/avXgIgi6drj8dp1fWA=
     def test_crypto_container_str_returns_cipher_payload(self):
         data = b"abcde"
         crypto_container = tlsc.CryptoContainer(self.tls_ctx, data)
-        padding = crypto_container.pad()
-        self.assertEqual("%s%s%s%s" % (data, crypto_container.hmac(), padding, chr(len(padding))), str(crypto_container))
+        padding = crypto_container.padding
+        self.assertEqual("%s%s%s%s" % (data, crypto_container.mac, padding, chr(len(padding))), str(crypto_container))
 
     def test_cipher_payload_is_block_size_aligned(self):
         data = b"A"*1025


### PR DESCRIPTION
- TLSSocket proxies the socket class. It serializes and inserts
packets into TLSSessionCtx
- Fixed a bug in CryptoContainer where padding was added for stream
ciphers
- Modified TLS connection example to use TLSSocket
- TLSSocket should make all this usable within the scapy CLI, which
is a nice win