### PR TITLE
Fixes AttributeError in TLSSecurityParameters and adds a utility function for bundled pem files.

### DIFF
--- a/scapy_ssl_tls/ssl_tls_crypto.py
+++ b/scapy_ssl_tls/ssl_tls_crypto.py
@@ -284,7 +284,9 @@ class TLSSessionCtx(object):
                     # fetch randombytes for crypto stuff
                     if not self.crypto.session.randombytes.client:
                         self.crypto.session.randombytes.client = struct.pack("!I", p[tls.TLSClientHello].gmt_unix_time) + p[tls.TLSClientHello].random_bytes
-
+                    # Generate a random PMS. Overriden at decryption time if private key is provided
+                    if self.crypto.session.premaster_secret is None:
+                        self.crypto.session.premaster_secret = self._generate_random_pms(self.params.negotiated.version)
             if p.haslayer(tls.TLSServerHello):
                 if not self.params.handshake.server:
                     self.params.handshake.server = p[tls.TLSServerHello]
@@ -292,9 +294,6 @@ class TLSSessionCtx(object):
                     #fetch randombytes
                     if not self.crypto.session.randombytes.server:
                         self.crypto.session.randombytes.server = struct.pack("!I", p[tls.TLSServerHello].gmt_unix_time) + p[tls.TLSServerHello].random_bytes
-                    # Generate a random PMS. Overriden at decryption time if private key is provided
-                    if self.crypto.session.premaster_secret is None:
-                        self.crypto.session.premaster_secret = self._generate_random_pms(self.params.negotiated.version)
                 # negotiated params
                 if not self.params.negotiated.ciphersuite:
                     self.params.negotiated.ciphersuite = p[tls.TLSServerHello].cipher_suite

--- a/scapy_ssl_tls/ssl_tls_crypto.py
+++ b/scapy_ssl_tls/ssl_tls_crypto.py
@@ -9,6 +9,7 @@ import copy
 import os
 import struct
 import zlib
+import re
 import pkcs7
 import ssl_tls as tls
 
@@ -35,6 +36,14 @@ https://tools.ietf.org/html/rfc4346#section-6.3
 '''
 def prf(master_secret, label, data):
     pass
+
+REX_PEM = re.compile(r'(\-+BEGIN\s*([^\-]+)\-+(.*?)\-+END[^\-]+\-+)', re.DOTALL)
+def pem_get_objects(data):
+    d = {}
+    for full, pemtype, pemdata in REX_PEM.findall(data):
+        d[pemtype]={'data':data,
+                    'full':full}
+    return d
 
 def x509_extract_pubkey_from_der(der_certificate):
     # Extract subjectPublicKeyInfo field from X.509 certificate (see RFC3280)
@@ -275,9 +284,6 @@ class TLSSessionCtx(object):
                     # fetch randombytes for crypto stuff
                     if not self.crypto.session.randombytes.client:
                         self.crypto.session.randombytes.client = struct.pack("!I", p[tls.TLSClientHello].gmt_unix_time) + p[tls.TLSClientHello].random_bytes
-                    # Generate a random PMS. Overriden at decryption time if private key is provided
-                    if self.crypto.session.premaster_secret is None:
-                        self.crypto.session.premaster_secret = self._generate_random_pms(self.params.negotiated.version)
 
             if p.haslayer(tls.TLSServerHello):
                 if not self.params.handshake.server:
@@ -286,6 +292,9 @@ class TLSSessionCtx(object):
                     #fetch randombytes
                     if not self.crypto.session.randombytes.server:
                         self.crypto.session.randombytes.server = struct.pack("!I", p[tls.TLSServerHello].gmt_unix_time) + p[tls.TLSServerHello].random_bytes
+                    # Generate a random PMS. Overriden at decryption time if private key is provided
+                    if self.crypto.session.premaster_secret is None:
+                        self.crypto.session.premaster_secret = self._generate_random_pms(self.params.negotiated.version)
                 # negotiated params
                 if not self.params.negotiated.ciphersuite:
                     self.params.negotiated.ciphersuite = p[tls.TLSServerHello].cipher_suite
@@ -356,8 +365,10 @@ class TLSSessionCtx(object):
 
     def rsa_load_keys_from_file(self, priv_key_file):
         with open(priv_key_file,'r') as f:
-            self.crypto.server.rsa.privkey, self.crypto.server.rsa.pubkey = self._rsa_load_keys(f.read())
-    
+            # _rsa_load_keys expects one pem/der key per file.
+            privkey = pem_get_objects(f.read()).get("RSA PRIVATE KEY",{}).get("full")
+            self.crypto.server.rsa.privkey, self.crypto.server.rsa.pubkey = self._rsa_load_keys(privkey)
+
     def rsa_load_keys(self, priv_key):
         self.crypto.server.rsa.privkey, self.crypto.server.rsa.pubkey = self._rsa_load_keys(priv_key)
 
@@ -724,7 +735,7 @@ class TLSSecurityParameters(object):
         s=[]
         for f in (f for f in dir(self) if "_write_" in f):
             s.append( "%20s | %s"%(f,repr(getattr(self,f))))
-        s.append("%20s| %s" % ("premaster_secret", repr(self.premaster_secret)))
+        s.append("%20s| %s" % ("premaster_secret", repr(self.pms)))
         s.append("%20s| %s" % ("master_secret", repr(self.master_secret)))
         s.append("%20s| %s" % ("master_secret [bytes]", binascii.hexlify(self.master_secret)))
         return "\n".join(s)

--- a/tests/test_ssl_tls_crypto.py
+++ b/tests/test_ssl_tls_crypto.py
@@ -105,9 +105,9 @@ xVgf/Neb/avXgIgi6drj8dp1fWA=
         with self.assertRaises(ValueError):
             tls_ctx.get_encrypted_pms()
 
-    def test_random_pms_is_generated_on_client_hello(self):
+    def test_random_pms_is_generated_on_server_hello(self):
         tls_ctx = tlsc.TLSSessionCtx()
-        pkt = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSClientHello(version=0x0301)
+        pkt = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSServerHello(version=0x0301)
         tls_ctx.insert(pkt)
         self.assertIsNotNone(tls_ctx.crypto.session.premaster_secret)
 
@@ -131,9 +131,9 @@ xVgf/Neb/avXgIgi6drj8dp1fWA=
         tls_ctx.rsa_load_keys(self.pem_priv_key)
         pkt = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSClientHello()
         tls_ctx.insert(pkt)
-        epms = tls_ctx.get_encrypted_pms()
         pkt = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSServerHello()
         tls_ctx.insert(pkt)
+        epms = tls_ctx.get_encrypted_pms()
         pkt = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSClientKeyExchange()/epms
         tls_ctx.insert(pkt)
         self.assertEqual(tls_ctx.crypto.session.encrypted_premaster_secret, epms)

--- a/tests/test_ssl_tls_crypto.py
+++ b/tests/test_ssl_tls_crypto.py
@@ -105,9 +105,9 @@ xVgf/Neb/avXgIgi6drj8dp1fWA=
         with self.assertRaises(ValueError):
             tls_ctx.get_encrypted_pms()
 
-    def test_random_pms_is_generated_on_server_hello(self):
+    def test_random_pms_is_generated_on_client_hello(self):
         tls_ctx = tlsc.TLSSessionCtx()
-        pkt = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSServerHello(version=0x0301)
+        pkt = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSClientHello(version=0x0301)
         tls_ctx.insert(pkt)
         self.assertIsNotNone(tls_ctx.crypto.session.premaster_secret)
 
@@ -131,9 +131,9 @@ xVgf/Neb/avXgIgi6drj8dp1fWA=
         tls_ctx.rsa_load_keys(self.pem_priv_key)
         pkt = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSClientHello()
         tls_ctx.insert(pkt)
+        epms = tls_ctx.get_encrypted_pms()
         pkt = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSServerHello()
         tls_ctx.insert(pkt)
-        epms = tls_ctx.get_encrypted_pms()
         pkt = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSClientKeyExchange()/epms
         tls_ctx.insert(pkt)
         self.assertEqual(tls_ctx.crypto.session.encrypted_premaster_secret, epms)


### PR DESCRIPTION
- fix attributeerror self.premaster_secret …
- generate random pms on server_hello
- add pem handling functionality to allow selection of private key/certificate from bundled pem files (e.g. tests/files/openssl_1_0_1_f_server.pem)