### PR TITLE
Tls1.1 support

### DIFF
--- a/examples/full_rsa_connection_with_application_data.py
+++ b/examples/full_rsa_connection_with_application_data.py
@@ -9,16 +9,18 @@ from scapy.all import conf
 from scapy_ssl_tls.ssl_tls import *
 from scapy_ssl_tls.ssl_tls_crypto import *
 
+tls_version = TLSVersion.TLS_1_1
+
 def tls_hello(sock):
-    client_hello = TLSRecord(version="TLS_1_1")/TLSHandshake()/TLSClientHello(version="TLS_1_1", compression_methods=[0],
-                                                                              cipher_suites=(TLSCipherSuite.RSA_WITH_RC4_128_SHA))
+    client_hello = TLSRecord(version=tls_version)/TLSHandshake()/TLSClientHello(version=tls_version, compression_methods=[0],
+                                                                            cipher_suites=(TLSCipherSuite.RSA_WITH_AES_256_CBC_SHA))
     sock.sendall(client_hello)
     server_hello = sock.recvall()
     server_hello.show()
 
 def tls_client_key_exchange(sock):
-    client_key_exchange = TLSRecord()/TLSHandshake()/TLSClientKeyExchange()/sock.tls_ctx.get_encrypted_pms()
-    client_ccs = TLSRecord()/TLSChangeCipherSpec()
+    client_key_exchange = TLSRecord(version=tls_version)/TLSHandshake()/TLSClientKeyExchange()/sock.tls_ctx.get_encrypted_pms()
+    client_ccs = TLSRecord(version=tls_version)/TLSChangeCipherSpec()
     sock.sendall(TLS.from_records([client_key_exchange, client_ccs]))
     sock.sendall(to_raw(TLSFinished(), sock.tls_ctx))
     server_finished = sock.recvall()

--- a/examples/full_rsa_connection_with_application_data.py
+++ b/examples/full_rsa_connection_with_application_data.py
@@ -10,7 +10,7 @@ from scapy_ssl_tls.ssl_tls import *
 from scapy_ssl_tls.ssl_tls_crypto import *
 
 def tls_hello(sock):
-    client_hello = TLSRecord(version="TLS_1_0")/TLSHandshake()/TLSClientHello(version="TLS_1_0", compression_methods=[0],
+    client_hello = TLSRecord(version="TLS_1_1")/TLSHandshake()/TLSClientHello(version="TLS_1_1", compression_methods=[0],
                                                                               cipher_suites=(TLSCipherSuite.RSA_WITH_RC4_128_SHA))
     sock.sendall(client_hello)
     server_hello = sock.recvall()
@@ -40,8 +40,6 @@ def tls_client(ip, priv_key=None):
         resp = sock.recvall()
         print("Got response from server")
         resp.show()
-        close_notify = sock.sendall(to_raw(TLSAlert(level=TLSAlertLevel.WARNING, description=TLSAlertDescription.CLOSE_NOTIFY), sock.tls_ctx))
-        print("Sending close notify to tear down connection")
     finally:
         sock.close()
 

--- a/tests/integration/openssl_tls_server.sh
+++ b/tests/integration/openssl_tls_server.sh
@@ -12,4 +12,5 @@ script_dir="$(dirname "$(${readlink} -f "${0}")")"
 cd "${script_dir}"
 
 openssl s_server -accept 8443 -www -debug -msg -key keys/key.pem -cert keys/cert.pem -tls1 -no_ssl3
-#openssl s_server -accept 8443 -www -key keys/server-key.pem -cert keys/server-cert.pem -tls1 -no_ssl3 > /dev/null 2>&1 &
+#openssl s_server -accept 8443 -www -debug -msg -key keys/key.pem -cert keys/cert.pem -tls1_1 -no_ssl3
+#openssl s_server -accept 8443 -www -debug -msg -key keys/key.pem -cert keys/cert.pem -tls1_2 -no_ssl3


### PR DESCRIPTION
    Added TLS 1.1 support
    
    - Support for TLS 1.1 explicit IVs is complete. Stream ciphers remain
    unchanged, block ciphers use explicit IVs
    - Added a few integration switches to s_server to test tls 1.1
    - Added unittests coverage