### PR TITLE
Corrected naming of TLSServerKeyExchange class.

### DIFF
--- a/scapy_ssl_tls/ssl_tls.py
+++ b/scapy_ssl_tls/ssl_tls.py
@@ -413,7 +413,7 @@ class TLSClientKeyExchange(Packet):
     fields_desc = [ XBLenField("length", None, fmt="!H",) ]
     
 class TLSServerKeyExchange(Packet):
-    name = "TLS Client Key Exchange"
+    name = "TLS Server Key Exchange"
     fields_desc = [ XBLenField("length", None, fmt="!H") ]
 
 class TLSKexParamDH(Packet):


### PR DESCRIPTION
Seems like a copy & waste issue. Fixed naming of TLSServerKeyExchange class.