### PR TITLE
Fix conditional extension length for rdpcap/sniff - fixes #40

### DIFF
--- a/scapy_ssl_tls/ssl_tls.py
+++ b/scapy_ssl_tls/ssl_tls.py
@@ -403,7 +403,7 @@ class TLSClientHello(Packet):
                    XFieldLenField("compression_methods_length", None, length_of="compression_methods", fmt="B"),
                    FieldListField("compression_methods", [TLSCompressionMethod.NULL], ByteEnumField("compression", None, TLS_COMPRESSION_METHODS), length_from=lambda x:x.compression_methods_length),
                    
-                   StrConditionalField(XFieldLenField("extensions_length", None, length_of="extensions", fmt="H"), lambda pkt,s,val: True if val or (s and struct.unpack("!H",s[:2])[0]==len(s)-2) else False),
+                   StrConditionalField(XFieldLenField("extensions_length", None, length_of="extensions", fmt="H"), lambda pkt,s,val: True if val or pkt.extensions or (s and struct.unpack("!H",s[:2])[0]==len(s)-2) else False),
                    PacketListField("extensions", None, TLSExtension, length_from=lambda x:x.extensions_length),
                    ] 
  
@@ -418,7 +418,7 @@ class TLSServerHello(Packet):
                    XShortEnumField("cipher_suite", TLSCipherSuite.NULL_WITH_NULL_NULL, TLS_CIPHER_SUITES),
                    ByteEnumField("compression_method", TLSCompressionMethod.NULL, TLS_COMPRESSION_METHODS),
 
-                   StrConditionalField(XFieldLenField("extensions_length", None, length_of="extensions", fmt="H"), lambda pkt,s,val: True if val or (s and struct.unpack("!H",s[:2])[0]==len(s)-2) else False),
+                   StrConditionalField(XFieldLenField("extensions_length", None, length_of="extensions", fmt="H"), lambda pkt,s,val: True if val or pkt.extensions or (s and struct.unpack("!H",s[:2])[0]==len(s)-2) else False),
                    PacketListField("extensions", None, TLSExtension, length_from=lambda x:x.extensions_length),
                    ]
 
@@ -614,7 +614,7 @@ class DTLSClientHello(Packet):
                    XFieldLenField("compression_methods_length", None, length_of="compression_methods", fmt="B"),
                    FieldListField("compression_methods", None, ByteEnumField("compression", None, TLS_COMPRESSION_METHODS), length_from=lambda x:x.compression_methods_length),
                    
-                   StrConditionalField(XFieldLenField("extensions_length", None, length_of="extensions", fmt="H"), lambda pkt,s,val: True if val else False),
+                   StrConditionalField(XFieldLenField("extensions_length", None, length_of="extensions", fmt="H"), lambda pkt,s,val: True if val or pkt.extensions or (s and struct.unpack("!H",s[:2])[0]==len(s)-2) else False),
                    PacketListField("extensions", None, TLSExtension, length_from=lambda x:x.extensions_length),
                    ]   
     

--- a/tests/test_ssl_tls.py
+++ b/tests/test_ssl_tls.py
@@ -276,6 +276,11 @@ class TestTLSClientHello(unittest.TestCase):
         self.assertEquals(ext[tls.TLSExtServerNameIndication].server_names[1].data,"github.com") 
         self.assertEquals(ext[tls.TLSExtServerNameIndication].server_names[0].data,"www.github.com")
 
+    def test_dissect_client_hello_conditional_extensions_length(self):
+        hello = tls.SSL(str(self.pkt))[tls.TLSClientHello]
+        self.assertTrue("extensions_length=" in repr(hello))
+        self.assertEqual(hello.extensions_length, len(''.join(str(e) for e in hello.extensions)))
+
 class TestTLSPlaintext(unittest.TestCase):
 
     def test_built_plaintext_has_no_mac_and_padding_when_unspecified(self):
@@ -301,7 +306,12 @@ class TestPCAP(unittest.TestCase):
         for p in (pkt for pkt in self.pkts):
             self.records += p.records
         unittest.TestCase.setUp(self)
-          
+    
+    def test_pcap_hello_conditional_extensions_length(self):
+        for r in (rec for rec in self.records if rec.haslayer(tls.TLSServerHello) or rec.haslayer(tls.TLSClientHello)):
+            self.assertTrue("extensions_length=" in repr(r))
+            self.assertEqual(r.extensions_length, len(''.join(str(e) for e in r.extensions)))
+      
     def test_pcap_record_order(self):
         pkts = self.records
         pkts.reverse()


### PR DESCRIPTION
changed the field contitionto to include extensions_length if
* val is set (is set when packet is build from scratch)
* pkt.extensions is set (rdpcap/sniff) - new
* s, the raw bytestream looks like the extensions_length field and fits the pkt length

need to add some unit tests before we can merge this.