### PR TITLE
Added Record fragmentation handling

### DIFF
--- a/scapy_ssl_tls/ssl_tls.py
+++ b/scapy_ssl_tls/ssl_tls.py
@@ -764,12 +764,7 @@ class TLSSocket(object):
     def sendall(self, pkt, timeout=2):
         prev_timeout = self._s.gettimeout()
         self._s.settimeout(timeout)
-        try:
-            pkt_bytes = str(pkt)
-        except TLSFragmentationError:
-            pkt = tls_fragment_payload(pkt.payload, pkt)
-            pkt_bytes = str(pkt)
-        self._s.sendall(pkt_bytes)
+        self._s.sendall(str(pkt))
         self.tls_ctx.insert(pkt)
         self._s.settimeout(prev_timeout)
 

--- a/scapy_ssl_tls/ssl_tls.py
+++ b/scapy_ssl_tls/ssl_tls.py
@@ -312,7 +312,7 @@ class TLSRecord(StackedLenPacket):
         return p
 
     def fragment(self, size=2**14):
-        return tls_fragment_payload(str(self.payload), self, size)
+        return tls_fragment_payload(self.payload, self, size)
 
 
 class TLSServerName(PacketNoPadding):
@@ -952,9 +952,10 @@ def tls_do_handshake(tls_socket, version, ciphers):
     tls_socket.sendall(to_raw(TLSFinished(), tls_socket.tls_ctx))
     tls_socket.recvall()
 
-def tls_fragment_payload(payload, record=None, size=2**14):
+def tls_fragment_payload(pkt, record=None, size=2**14):
     if size <= 0:
         raise ValueError("Fragment size must be strictly positive")
+    payload = str(pkt)
     payloads = [payload[i: i+size] for i in range(0, len(payload), size)]
     if record is None:
         return payloads

--- a/scapy_ssl_tls/ssl_tls.py
+++ b/scapy_ssl_tls/ssl_tls.py
@@ -764,7 +764,12 @@ class TLSSocket(object):
     def sendall(self, pkt, timeout=2):
         prev_timeout = self._s.gettimeout()
         self._s.settimeout(timeout)
-        self._s.sendall(str(pkt))
+        try:
+            pkt_bytes = str(pkt)
+        except TLSFragmentationError:
+            pkt = tls_fragment_payload(pkt.payload, pkt)
+            pkt_bytes = str(pkt)
+        self._s.sendall(pkt_bytes)
         self.tls_ctx.insert(pkt)
         self._s.settimeout(prev_timeout)
 

--- a/scapy_ssl_tls/ssl_tls.py
+++ b/scapy_ssl_tls/ssl_tls.py
@@ -263,13 +263,18 @@ class TLSKexNames(object):
     DHE = "DHE"
     ECDHE = "ECDHE"
 
+class TLSFragmentationError(Exception):
+    pass
+
 class TLSRecord(StackedLenPacket):
+    MAX_LEN = 2**16 - 1
     name = "TLS Record"
     fields_desc = [ByteEnumField("content_type", TLSContentType.APPLICATION_DATA, TLS_CONTENT_TYPES),
                    XShortEnumField("version", TLSVersion.TLS_1_0, TLS_VERSIONS),
                    XLenField("length", None, fmt="!H"), ]
 
     def __init__(self, *args, **fields):
+        self.fragments = []
         try:
             self.tls_ctx = fields["ctx"]
             del(fields["ctx"])
@@ -291,18 +296,24 @@ class TLSRecord(StackedLenPacket):
             pass
         return cls
 
+    def do_build(self):
+        """
+        Taken as is from superclass. Just raises exception when payload can't fit in a TLSRecord
+        """
+        if not self.explicit:
+            self = self.__iter__().next()
+        if len(self.payload) > TLSRecord.MAX_LEN:
+            raise TLSFragmentationError()
+        pkt = self.self_build()
+        for t in self.post_transforms:
+            pkt = t(pkt)
+        pay = self.do_build_payload()
+        p = self.post_build(pkt,pay)
+        return p
+
     def fragment(self, size=2**14):
-        payload = str(self.payload)
-        payloads = [payload[i: i+size] for i in range(0, len(self.payload), size)]
-        fragments = []
-        for payload in payloads:
-            fragments.append(TLSRecord(content_type=self.content_type, version=self.version, length=len(payload)) /
-                             payload)
-        try:
-            stack = TLS.from_records(fragments, ctx=self.tls_ctx)
-        except struct.error as se:
-            raise ValueError("Fragment offset must be block aligned: %s" % se)
-        return stack
+        return tls_fragment_payload(str(self.payload), self, size)
+
 
 class TLSServerName(PacketNoPadding):
     name = "TLS Servername"
@@ -738,7 +749,8 @@ class TLSSocket(object):
         except socket.error as se:
             # OSX and BSDs do not support ENOPROTOOPT. Linux and Windows seem to
             if se.errno == errno.ENOPROTOOPT:
-                raise RuntimeError("OS does not support SO_ACCEPTCONN, cannot determine socket state. Please supply an explicit client value (True for client, False for server)")
+                raise RuntimeError("OS does not support SO_ACCEPTCONN, cannot determine socket state. Please supply an"
+                                   "explicit client value (True for client, False for server)")
             else:
                 raise
         return True if is_listening != 0 else False
@@ -771,6 +783,7 @@ class TLSSocket(object):
         self._s.settimeout(prev_timeout)
         records = TLS("".join(resp), ctx=self.tls_ctx)
         return records
+
 
 # entry class
 class SSL(Packet):
@@ -939,6 +952,23 @@ def tls_do_handshake(tls_socket, version, ciphers):
     tls_socket.sendall(to_raw(TLSFinished(), tls_socket.tls_ctx))
     tls_socket.recvall()
 
+def tls_fragment_payload(payload, record=None, size=2**14):
+    if size <= 0:
+        raise ValueError("Fragment size must be strictly positive")
+    payloads = [payload[i: i+size] for i in range(0, len(payload), size)]
+    if record is None:
+        return payloads
+    else:
+        fragments = []
+        for payload in payloads:
+            fragments.append(TLSRecord(content_type=record.content_type, version=record.version, length=len(payload)) /
+                             payload)
+            try:
+                stack = TLS.from_records(fragments, ctx=record.tls_ctx)
+            except struct.error as se:
+                raise TLSFragmentationError("Fragment size must be a power of 2: %s" % se)
+        return stack
+
 # bind magic
 bind_layers(TCP, SSL, dport=443)
 bind_layers(TCP, SSL, sport=443)
@@ -950,7 +980,6 @@ bind_layers(TLSRecord, TLSChangeCipherSpec, {'content_type':TLSContentType.CHANG
 bind_layers(TLSRecord, TLSCiphertext, {"content_type":TLSContentType.APPLICATION_DATA})
 bind_layers(TLSRecord, TLSHeartBeat, {'content_type':TLSContentType.HEARTBEAT})
 bind_layers(TLSRecord, TLSAlert, {'content_type':TLSContentType.ALERT})
-
 bind_layers(TLSRecord, TLSHandshake, {'content_type':TLSContentType.HANDSHAKE})
 
 # --> handshake proto


### PR DESCRIPTION
- Records above 2^16 - 1 raise a TLSFragmentationError. It's up to the user to fragment on the RFC 2^14 boundary
- Provided helper functions to assist with fragmentation 