### PR TITLE
Full TLS 1.2 support

### DIFF
--- a/scapy_ssl_tls/ssl_tls_crypto.py
+++ b/scapy_ssl_tls/ssl_tls_crypto.py
@@ -33,8 +33,6 @@ https://tools.ietf.org/html/rfc4346#section-6.3
        client_write_key[SecurityParameters.key_material_length]
        server_write_key[SecurityParameters.key_material_length]
 '''
-def prf(master_secret, label, data):
-    pass
 
 REX_PEM = re.compile(r'(\-+BEGIN\s*([^\-]+)\-+(.*?)\-+END[^\-]+\-+)', re.DOTALL)
 def pem_get_objects(data):
@@ -495,7 +493,8 @@ class TLSSessionCtx(object):
     def set_mode(self, client=None, server=None):
         self.client=client if client else not server
         self.server= not self.client
-        
+
+
 class TLSPRF(object):
     TLS_MD_CLIENT_FINISH_CONST = "client finished"
     TLS_MD_SERVER_FINISH_CONST = "server finished"
@@ -505,8 +504,7 @@ class TLSPRF(object):
     TLS_MD_SERVER_WRITE_KEY_CONST = "server write key"
     TLS_MD_IV_BLOCK_CONST = "IV block"
     TLS_MD_MASTER_SECRET_CONST = "master secret"
-    
-    
+
     def __init__(self, algorithm):
         self.algorithm = algorithm
     
@@ -803,7 +801,7 @@ class TLSSecurityParameters(object):
             return self.cipher_type.new(self.client_write_key, mode=self.cipher_mode, IV=self.client_write_IV)
         else:
             return self.__client_dec_cipher
-#         
+
     def __init_key_material(self, data, explicit_iv):
         i = 0
         self.client_write_MAC_key = data[i:i+self.mac_key_length]

--- a/scapy_ssl_tls/ssl_tls_crypto.py
+++ b/scapy_ssl_tls/ssl_tls_crypto.py
@@ -3,7 +3,6 @@
 # Author : tintinweb@oststrom.com <github.com/tintinweb>
 # http://www.secdev.org/projects/scapy/doc/build_dissect.html
 
-import array
 import binascii
 import copy
 import os
@@ -161,13 +160,13 @@ class TLSSessionCtx(object):
                                                      'master_secret',
                                                      "prf"])
         
-        self.crypto.session.encrypted_premaster_secret=None
-        self.crypto.session.premaster_secret=None
-        self.crypto.session.master_secret=None
-        self.crypto.session.prf = TLSPRF(SHA256)
+        self.crypto.session.encrypted_premaster_secret = None
+        self.crypto.session.premaster_secret = None
+        self.crypto.session.master_secret = None
+        self.crypto.session.prf = None
         self.crypto.session.randombytes = namedtuple('randombytes',['client','server'])
-        self.crypto.session.randombytes.client=None
-        self.crypto.session.randombytes.server=None
+        self.crypto.session.randombytes.client = None
+        self.crypto.session.randombytes.server = None
         
         self.crypto.session.key = namedtuple('key',['client','server'])
         self.crypto.session.key.server = namedtuple('server',['mac','encryption','iv', "seq_num"])
@@ -323,6 +322,7 @@ class TLSSessionCtx(object):
                 if not self.params.handshake.server:
                     self.params.handshake.server = p[tls.TLSServerHello]
                     self.params.negotiated.version = p[tls.TLSServerHello].version
+                    self.crypto.session.prf = TLSPRF(self.params.negotiated.version)
                     #fetch randombytes
                     if not self.crypto.session.randombytes.server:
                         self.crypto.session.randombytes.server = struct.pack("!I", p[tls.TLSServerHello].gmt_unix_time) + p[tls.TLSServerHello].random_bytes
@@ -379,7 +379,8 @@ class TLSSessionCtx(object):
                     self.crypto.client.dh.y_c = p[tls.TLSClientKeyExchange].data
 
                 explicit_iv = True if self.params.negotiated.version > tls.TLSVersion.TLS_1_0 else False
-                self.sec_params = TLSSecurityParameters(self.params.negotiated.ciphersuite,
+                self.sec_params = TLSSecurityParameters(self.crypto.session.prf,
+                                                        self.params.negotiated.ciphersuite,
                                                         self.crypto.session.premaster_secret,
                                                         self.crypto.session.randombytes.client,
                                                         self.crypto.session.randombytes.server,
@@ -484,10 +485,10 @@ class TLSSessionCtx(object):
                 if not handshake.haslayer(tls.TLSFinished) and not handshake.haslayer(tls.TLSHelloRequest):
                     verify_data.append(str(handshake))
 
-        prf_verify_data = self.crypto.session.prf.prf_numbytes(self.crypto.session.master_secret,
-                                                               label,
-                                                               "%s%s" % (MD5.new("".join(verify_data)).digest(), SHA.new("".join(verify_data)).digest()),
-                                                               numbytes=12)
+        prf_verify_data = self.crypto.session.prf.get_bytes(self.crypto.session.master_secret, label,
+                                                               "%s%s" % (MD5.new("".join(verify_data)).digest(),
+                                                                         SHA.new("".join(verify_data)).digest()),
+                                                               num_bytes=12)
         return prf_verify_data
 
     def set_mode(self, client=None, server=None):
@@ -498,98 +499,43 @@ class TLSSessionCtx(object):
 class TLSPRF(object):
     TLS_MD_CLIENT_FINISH_CONST = "client finished"
     TLS_MD_SERVER_FINISH_CONST = "server finished"
-    TLS_MD_SERVER_WRITE_KEY_CONST = "server write key"
     TLS_MD_KEY_EXPANSION_CONST = "key expansion"
     TLS_MD_CLIENT_WRITE_KEY_CONST = "client write key"
     TLS_MD_SERVER_WRITE_KEY_CONST = "server write key"
     TLS_MD_IV_BLOCK_CONST = "IV block"
     TLS_MD_MASTER_SECRET_CONST = "master secret"
 
-    def __init__(self, algorithm):
-        self.algorithm = algorithm
-    
-    def p_hash(self, secret, seed):
-        a_i = seed              # i=0
-        ''' 1) 
-        ##############i=0    hmac_hash(secret, seed+seed) +
-        i=1    hmac_hash(secret, hmac_hash(secret, seed) +seed) +
-        i=2    hmac_hash(secret, hmac_hash(secret, 
-        '''
-        
-        #start at i=1
-        while True:
-            a_i = HMAC.new(key=secret, msg=a_i, digestmod=self.algorithm).digest()      # i=1
-            yield HMAC.new(key=secret, msg=a_i+seed, digestmod=self.algorithm).digest()
-        
-    def prf(self, secret, label, seed):
-        for block in self.p_hash(secret, label+seed):
-            yield block
-            
-    def prf_numbytes(self, secret, label, random, numbytes):
-        hs = (len(secret)+1)/2
-        s1 = secret[:hs]
-        s2 = secret[-hs:]
-        
-        #print "randlen=",len(random)
-        #print "hs=",hs
-        #print "s1=",s1
-        #print "s2=",s2
-        #print "label+random=",label+random
-        #print "label=",label
-        #1) compute P_md5(secret_part_1, label+random)   
-        md5_hmac=''
-        block=HMAC.new(key=s1, 
-                       msg=label+random,
-                       digestmod=MD5).digest() 
-        while len(md5_hmac)<numbytes:
-            md5_hmac += HMAC.new(key=s1, 
-                             msg=block+label+random,
-                             digestmod=MD5).digest()
-            
-            block = HMAC.new(key=s1, 
-                             msg=block,
-                             digestmod=MD5).digest()
-            #print [ "%.2x"%ord(i) for i in md5_hmac]
-            
-        md5_hmac=md5_hmac[:numbytes]
-        # sha stuff
-        sha_hmac=''
-        block=HMAC.new(key=s2, 
-                       msg=label+random,
-                       digestmod=SHA).digest() 
-        while len(sha_hmac)<numbytes:
-            sha_hmac += HMAC.new(key=s2, 
-                             msg=block+label+random,
-                             digestmod=SHA).digest()
-            
-            block = HMAC.new(key=s2, 
-                             msg=block,
-                             digestmod=SHA).digest()
-            #print [ "%.2x"%ord(i) for i in sha_hmac]
-        # XOR both strings
-        sha_hmac=sha_hmac[:numbytes]              
-        
-        m = array.array("B",md5_hmac)
-        s = array.array("B",sha_hmac)
+    def __init__(self, tls_version):
+        if tls_version not in tls.TLS_VERSIONS.keys():
+            raise ValueError("Unknown TLS version: %d" % tls_version)
+        self.tls_version = tls_version
 
-        for i in xrange(numbytes):
-            m[i] ^= s[i]
-            #print "%0.2x"%m[i],
-            
-        return m.tostring()
-        
-        '''
-        data  = ''
-        for block in self.prf(secret,label,seed):
-            data +=block
-            if len(data)>=numbytes:
-                return data[:numbytes]
-        '''    
-    def hmac(self, key, msg):
-        return HMAC.new(key=key, msg=msg, digestmod=self.algorithm).digest()
-    
-    def hash(self, msg):
-        return self.algorithm.new(msg).digest()
+    def get_bytes(self, key, label, random, num_bytes):
+        bytes_ = ""
+        if self.tls_version <= tls.TLSVersion.TLS_1_1:
+            key_len = (len(key) + 1) // 2
+            key_left = key[:key_len]
+            key_right = key[-key_len:]
+
+            # Get bytes from MD5
+            md5_bytes = self._get_bytes(MD5, key_left, label, random, num_bytes)
+            # Get bytes from SHA1
+            sha1_bytes = self._get_bytes(SHA, key_right, label, random, num_bytes)
+
+            xored = []
+            for i in range(num_bytes):
+                xored.append(chr(ord(md5_bytes[i]) ^ ord(sha1_bytes[i])))
+            bytes_ = "".join(xored)
+        return bytes_
+
+    def _get_bytes(self, digest, key, label, random, num_bytes):
+        bytes_ = ""
+        block = HMAC.new(key=key, msg="%s%s" % (label, random), digestmod=digest).digest()
+        while len(bytes_) < num_bytes:
+            bytes_ += HMAC.new(key=key, msg="%s%s%s" % (block, label, random), digestmod=digest).digest()
+            block = HMAC.new(key=key, msg=block, digestmod=digest).digest()
+        return bytes_[:num_bytes]
+
 
 class CryptoContainer(object):
     
@@ -748,7 +694,7 @@ class TLSSecurityParameters(object):
 #         SRP_SHA_DSS_WITH_AES_256_CBC_SHA = 0xc022
 #         TLS_FALLBACK_SCSV = 0x5600
 
-    def __init__(self, cipher_suite, pms, client_random, server_random, explicit_iv=False):
+    def __init__(self, prf, cipher_suite, pms, client_random, server_random, explicit_iv=False):
         """ /!\ This class is not thread safe
         """
         try:
@@ -769,7 +715,7 @@ class TLSSecurityParameters(object):
         # Stream ciphers have a block size of one, but IV should be 0
         self.iv_length = 0 if block_size == 1 else block_size
         self.explicit_iv = explicit_iv
-        self.prf = TLSPRF(SHA256)
+        self.prf = prf
         self.__init_crypto(pms, client_random, server_random, explicit_iv)
     
     def get_client_hmac(self):
@@ -822,14 +768,14 @@ class TLSSecurityParameters(object):
             i += self.iv_length
         
     def __init_crypto(self, pms, client_random, server_random, explicit_iv):
-        self.master_secret = self.prf.prf_numbytes(pms,
+        self.master_secret = self.prf.get_bytes(pms,
                                                    TLSPRF.TLS_MD_MASTER_SECRET_CONST,
                                                    client_random + server_random, 
-                                                   numbytes=48)
-        key_block = self.prf.prf_numbytes(self.master_secret,
+                                                   num_bytes=48)
+        key_block = self.prf.get_bytes(self.master_secret,
                                           TLSPRF.TLS_MD_KEY_EXPANSION_CONST, 
                                           server_random + client_random, 
-                                          numbytes=2*(self.mac_key_length + self.cipher_key_length + self.iv_length) )
+                                          num_bytes=2*(self.mac_key_length + self.cipher_key_length + self.iv_length) )
         self.__init_key_material(key_block, explicit_iv)
         self.cipher_mode = self.negotiated_crypto_param["cipher"]["mode"]
         self.cipher_type = self.negotiated_crypto_param["cipher"]["type"]

--- a/tests/test_ssl_tls.py
+++ b/tests/test_ssl_tls.py
@@ -171,7 +171,9 @@ class TestTLSDecryptablePacket(unittest.TestCase):
     def test_streaming_mac_and_padding_are_added_if_session_context_is_provided(self):
         data = "%s%s" % ("A"*2, "B"*MD5.digest_size)
         tls_ctx = tlsc.TLSSessionCtx()
-        tls_ctx.sec_params = tlsc.TLSSecurityParameters(tls.TLSCipherSuite.RSA_EXPORT1024_WITH_RC4_56_MD5, "A"*48, "B"*32, "C"*32)
+        tls_ctx.sec_params = tlsc.TLSSecurityParameters(tlsc.TLSPRF(tls.TLSVersion.TLS_1_0),
+                                                        tls.TLSCipherSuite.RSA_EXPORT1024_WITH_RC4_56_MD5, "A"*48,
+                                                        "B"*32, "C"*32)
         records = tls.TLSAlert(data, ctx=tls_ctx)
         self.assertEqual("B"*MD5.digest_size, records[tls.TLSAlert].mac)
         self.assertEqual("", records[tls.TLSAlert].padding)
@@ -179,7 +181,8 @@ class TestTLSDecryptablePacket(unittest.TestCase):
     def test_cbc_mac_and_padding_are_added_if_session_context_is_provided(self):
         data = "%s%s%s" % ("A"*2, "B"*SHA.digest_size, "\x03"*4)
         tls_ctx = tlsc.TLSSessionCtx()
-        tls_ctx.sec_params = tlsc.TLSSecurityParameters(tls.TLSCipherSuite.RSA_WITH_DES_CBC_SHA, "A"*48, "B"*32, "C"*32)
+        tls_ctx.sec_params = tlsc.TLSSecurityParameters(tlsc.TLSPRF(tls.TLSVersion.TLS_1_0),
+                                                        tls.TLSCipherSuite.RSA_WITH_DES_CBC_SHA, "A"*48, "B"*32, "C"*32)
         records = tls.TLSAlert(data, ctx=tls_ctx)
         self.assertEqual(ord("\x03"), records[tls.TLSAlert].padding_len)
         self.assertEqual("\x03"*3, records[tls.TLSAlert].padding)
@@ -189,7 +192,9 @@ class TestTLSDecryptablePacket(unittest.TestCase):
         data = "%s%s%s%s" % ("C"*AES.block_size, "A"*2, "B"*SHA.digest_size, "\x03"*4)
         tls_ctx = tlsc.TLSSessionCtx()
         tls_ctx.params.negotiated.version = tls.TLSVersion.TLS_1_1
-        tls_ctx.sec_params = tlsc.TLSSecurityParameters(tls.TLSCipherSuite.RSA_WITH_AES_256_CBC_SHA, "A"*48, "B"*32, "C"*32, True)
+        tls_ctx.sec_params = tlsc.TLSSecurityParameters(tlsc.TLSPRF(tls.TLSVersion.TLS_1_0),
+                                                        tls.TLSCipherSuite.RSA_WITH_AES_256_CBC_SHA, "A"*48, "B"*32,
+                                                        "C"*32, True)
         records = tls.TLSAlert(data, ctx=tls_ctx)
         self.assertEqual(ord("\x03"), records[tls.TLSAlert].padding_len)
         self.assertEqual("\x03"*3, records[tls.TLSAlert].padding)

--- a/tests/test_ssl_tls_crypto.py
+++ b/tests/test_ssl_tls_crypto.py
@@ -5,15 +5,16 @@ import binascii
 import unittest
 import scapy_ssl_tls.ssl_tls as tls
 import scapy_ssl_tls.ssl_tls_crypto as tlsc
-from Crypto.Hash import HMAC, MD5, SHA
+from Crypto.Hash import HMAC, MD5, SHA, SHA256
 from Crypto.Cipher import AES, DES3, PKCS1_v1_5
 from Crypto.PublicKey import RSA
 
+
 def env_local_file(file):
-    return os.path.join(os.path.dirname(__file__),'files',file)
+    return os.path.join(os.path.dirname(__file__), 'files', file)
+
 
 class TestNullCiper(unittest.TestCase):
-
     def test_null_cipher_returns_cleartext_on_encrypt(self):
         null_cipher = tlsc.NullCipher.new(key="junk_key", iv="junk_iv")
         cleartext = "cleartext"
@@ -25,8 +26,8 @@ class TestNullCiper(unittest.TestCase):
         ciphertext = null_cipher.encrypt(cleartext)
         self.assertEqual(ciphertext, null_cipher.decrypt(ciphertext))
 
-class TestNullHash(unittest.TestCase):
 
+class TestNullHash(unittest.TestCase):
     def test_null_hash_always_returns_empty_string(self):
         null_hash = tlsc.NullHash.new("initial_junk")
         null_hash.update("some more junk")
@@ -38,9 +39,9 @@ class TestNullHash(unittest.TestCase):
         hmac.update("some more stuff")
         self.assertEqual("", hmac.digest())
         self.assertEqual("", hmac.hexdigest())
- 
-class TestTLSSessionCtx(unittest.TestCase):
 
+
+class TestTLSSessionCtx(unittest.TestCase):
     def setUp(self):
         self.pem_priv_key = """-----BEGIN PRIVATE KEY-----
 MIIEwAIBADANBgkqhkiG9w0BAQEFAASCBKowggSmAgEAAoIBAQDDLrmt4lKRpm6P
@@ -79,24 +80,29 @@ xVgf/Neb/avXgIgi6drj8dp1fWA=
     def test_negotiated_cipher_is_used_in_context(self):
         # RSA_WITH_NULL_MD5
         cipher_suite = 0x1
-        pkt = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSServerHello(gmt_unix_time=123456, random_bytes="A"*28, cipher_suite=cipher_suite)
+        pkt = tls.TLSRecord() / tls.TLSHandshake() / tls.TLSServerHello(gmt_unix_time=123456, random_bytes="A" * 28,
+                                                                        cipher_suite=cipher_suite)
         tls_ctx = tlsc.TLSSessionCtx()
         tls_ctx.insert(pkt)
-        self.assertEqual(tls_ctx.params.negotiated.key_exchange, tlsc.TLSSecurityParameters.crypto_params[cipher_suite]["key_exchange"]["name"])
-        self.assertEqual(tls_ctx.params.negotiated.mac, tlsc.TLSSecurityParameters.crypto_params[cipher_suite]["hash"]["name"])
+        self.assertEqual(tls_ctx.params.negotiated.key_exchange,
+                         tlsc.TLSSecurityParameters.crypto_params[cipher_suite]["key_exchange"]["name"])
+        self.assertEqual(tls_ctx.params.negotiated.mac,
+                         tlsc.TLSSecurityParameters.crypto_params[cipher_suite]["hash"]["name"])
 
     def test_negotiated_compression_method_is_used_in_context(self):
         # DEFLATE
         compression_method = 0x1
-        pkt = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSServerHello(gmt_unix_time=123456, random_bytes="A"*28, compression_method=compression_method)
+        pkt = tls.TLSRecord() / tls.TLSHandshake() / tls.TLSServerHello(gmt_unix_time=123456, random_bytes="A" * 28,
+                                                                        compression_method=compression_method)
         tls_ctx = tlsc.TLSSessionCtx()
         tls_ctx.insert(pkt)
-        self.assertEqual(tls_ctx.params.negotiated.compression_algo, tlsc.TLSCompressionParameters.comp_params[compression_method]["name"])
+        self.assertEqual(tls_ctx.params.negotiated.compression_algo,
+                         tlsc.TLSCompressionParameters.comp_params[compression_method]["name"])
         input_ = "some data" * 16
         self.assertEqual(tls_ctx.compression.method.decompress(tls_ctx.compression.method.compress(input_)), input_)
 
     def test_encrypted_pms_is_only_available_after_server_certificate_is_presented(self):
-        pkt = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSClientHello()
+        pkt = tls.TLSRecord() / tls.TLSHandshake() / tls.TLSClientHello()
         tls_ctx = tlsc.TLSSessionCtx()
         tls_ctx.insert(pkt)
         with self.assertRaises(ValueError):
@@ -104,28 +110,28 @@ xVgf/Neb/avXgIgi6drj8dp1fWA=
 
     def test_encrypting_pms_fails_if_no_certificate_in_connection(self):
         tls_ctx = tlsc.TLSSessionCtx()
-        pkt = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSClientHello(version=0x0301)
+        pkt = tls.TLSRecord() / tls.TLSHandshake() / tls.TLSClientHello(version=0x0301)
         tls_ctx.insert(pkt)
         with self.assertRaises(ValueError):
             tls_ctx.get_encrypted_pms()
 
     def test_random_pms_is_generated_on_client_hello(self):
         tls_ctx = tlsc.TLSSessionCtx()
-        pkt = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSClientHello(version=0x0301)
+        pkt = tls.TLSRecord() / tls.TLSHandshake() / tls.TLSClientHello(version=0x0301)
         tls_ctx.insert(pkt)
         self.assertIsNotNone(tls_ctx.crypto.session.premaster_secret)
 
     def test_keys_are_set_in_context_when_loaded(self):
         tls_ctx = tlsc.TLSSessionCtx()
-        pkt = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSClientHello(version=0x0301)
+        pkt = tls.TLSRecord() / tls.TLSHandshake() / tls.TLSClientHello(version=0x0301)
         tls_ctx.insert(pkt)
         tls_ctx.rsa_load_keys(self.pem_priv_key)
         self.assertIsNotNone(tls_ctx.crypto.server.rsa.privkey)
         self.assertIsNotNone(tls_ctx.crypto.server.rsa.pubkey)
         # Broken due to pycrypto bug: https://github.com/dlitz/pycrypto/issues/114
         # Uncomment when fixed upstream
-        #self.assertTrue(tls_ctx.crypto.server.rsa.privkey.can_decrypt())
-        #self.assertTrue(tls_ctx.crypto.server.rsa.pubkey.can_decrypt())
+        # self.assertTrue(tls_ctx.crypto.server.rsa.privkey.can_decrypt())
+        # self.assertTrue(tls_ctx.crypto.server.rsa.pubkey.can_decrypt())
         self.assertTrue(tls_ctx.crypto.server.rsa.privkey.can_encrypt())
         # TODO: Invertigate further: broken also in pycrypto. Should return False for public keys.
         # self.assertFalse(tls_ctx.crypto.server.rsa.pubkey.can_encrypt())
@@ -133,12 +139,12 @@ xVgf/Neb/avXgIgi6drj8dp1fWA=
     def test_decrypted_pms_matches_generated_pms(self):
         tls_ctx = tlsc.TLSSessionCtx()
         tls_ctx.rsa_load_keys(self.pem_priv_key)
-        pkt = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSClientHello()
+        pkt = tls.TLSRecord() / tls.TLSHandshake() / tls.TLSClientHello()
         tls_ctx.insert(pkt)
         epms = tls_ctx.get_encrypted_pms()
-        pkt = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSServerHello()
+        pkt = tls.TLSRecord() / tls.TLSHandshake() / tls.TLSServerHello()
         tls_ctx.insert(pkt)
-        pkt = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSClientKeyExchange(data=epms)
+        pkt = tls.TLSRecord() / tls.TLSHandshake() / tls.TLSClientKeyExchange(data=epms)
         tls_ctx.insert(pkt)
         self.assertEqual(tls_ctx.crypto.session.encrypted_premaster_secret, epms)
         self.assertEqual(tls_ctx.crypto.session.premaster_secret, self.priv_key.decrypt(epms, None))
@@ -146,14 +152,16 @@ xVgf/Neb/avXgIgi6drj8dp1fWA=
     def test_fixed_crypto_data_matches_verify_data(self):
         verify_data = "12003ac89553b7a233da64b9"
         tls_ctx = tlsc.TLSSessionCtx()
-        #tls_ctx.rsa_load_keys(self.pem_priv_key)
-        client_hello = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSClientHello(gmt_unix_time=1234, random_bytes="A"*28)
+        # tls_ctx.rsa_load_keys(self.pem_priv_key)
+        client_hello = tls.TLSRecord() / tls.TLSHandshake() / tls.TLSClientHello(gmt_unix_time=1234,
+                                                                                 random_bytes="A" * 28)
         tls_ctx.insert(client_hello)
-        tls_ctx.crypto.session.premaster_secret = "B"*48
-        epms = "C"*256
-        server_hello = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSServerHello(gmt_unix_time=1234, random_bytes="A"*28)
+        tls_ctx.crypto.session.premaster_secret = "B" * 48
+        epms = "C" * 256
+        server_hello = tls.TLSRecord() / tls.TLSHandshake() / tls.TLSServerHello(gmt_unix_time=1234,
+                                                                                 random_bytes="A" * 28)
         tls_ctx.insert(server_hello)
-        client_kex = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSClientKeyExchange(data=epms)
+        client_kex = tls.TLSRecord() / tls.TLSHandshake() / tls.TLSClientKeyExchange(data=epms)
         tls_ctx.insert(client_kex)
         self.assertEqual(binascii.hexlify(tls_ctx.get_verify_data()), verify_data)
 
@@ -164,16 +172,21 @@ xVgf/Neb/avXgIgi6drj8dp1fWA=
         tls_ctx.crypto.server.dh.y_s = "b\x1bF\xd4\xbe\xc6\x83d\x80\x1e\xeam\x86^\xcc!\xb2\x1b\x85+\xbd$j\xc9\x05\xf4\x14\x82 7\x8f_\x13\xcb\xef\xabyd\xb4\xc8\xda\xde\xac\xe8Zr\x8f\xb5\xfc\n\x16\xb0b\xf7\xd9!\x8d\x03\xef\n\r9\xd8\x87"
         client_privkey = 5398526532442504864680398257365369432058147704829279760748758494328728516319L
         client_pubkey = tls_ctx.get_client_dh_pubkey(client_privkey)
-        self.assertEqual("/T\xdc;\xc49\xa6\x8cD\xd4\xc1\x07I|\xb6\xc8\xaf\xb5\x04\xe9\xfb\t\x0e}\x14~\xa4\x1f\xdfo\x08u)Z\xb3\x0e\x1c^\xa3x0\x90\xa1\xd7\x82\x9dLT\xa6^\xcc\xf7\xae\x87\x97\x86vi\x02s\x10\xb3\xdbo", client_pubkey)
-        self.assertEqual("}\xcae\xd2y\xd7F$\xde\"\xa9s\xfbNR9v\x19t9\x87\xa8\xa3\x9c\xccb]\x13\xb7\x8a\x8f\xdf\x7fv\x05\xa6\xf1\xa7\xc8\xf4X\xe3\xd4\xac\xd6\x1e4\xb4\x1cc\xbb\xce\xbe\x94lQ\x91\xb9\xde\xb7\xa6gu_", tls_ctx.crypto.session.premaster_secret)
+        self.assertEqual(
+            "/T\xdc;\xc49\xa6\x8cD\xd4\xc1\x07I|\xb6\xc8\xaf\xb5\x04\xe9\xfb\t\x0e}\x14~\xa4\x1f\xdfo\x08u)Z\xb3\x0e\x1c^\xa3x0\x90\xa1\xd7\x82\x9dLT\xa6^\xcc\xf7\xae\x87\x97\x86vi\x02s\x10\xb3\xdbo",
+            client_pubkey)
+        self.assertEqual(
+            "}\xcae\xd2y\xd7F$\xde\"\xa9s\xfbNR9v\x19t9\x87\xa8\xa3\x9c\xccb]\x13\xb7\x8a\x8f\xdf\x7fv\x05\xa6\xf1\xa7\xc8\xf4X\xe3\xd4\xac\xd6\x1e4\xb4\x1cc\xbb\xce\xbe\x94lQ\x91\xb9\xde\xb7\xa6gu_",
+            tls_ctx.crypto.session.premaster_secret)
+
 
 class TestTLSSecurityParameters(unittest.TestCase):
-
     def setUp(self):
         self.pre_master_secret = "\x03\x01aaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbb"
         self.client_random = "a" * 32
         self.server_random = "z" * 32
-        self.master_secret = binascii.unhexlify("43278712b1feba3622c5745f79908a77b6e801239fc19390240cc45a17517b6218dfcb3f370c97f15329251e7a20ffb0")
+        self.master_secret = binascii.unhexlify(
+            "43278712b1feba3622c5745f79908a77b6e801239fc19390240cc45a17517b6218dfcb3f370c97f15329251e7a20ffb0")
         unittest.TestCase.setUp(self)
 
     def test_unsupported_cipher_suite_throws_exception(self):
@@ -183,15 +196,17 @@ class TestTLSSecurityParameters(unittest.TestCase):
     def test_building_with_supported_cipher_sets_lengths(self):
         # RSA_WITH_AES_128_CBC_SHA
         cipher_suite = 0x2f
-        sec_params = tlsc.TLSSecurityParameters(cipher_suite, self.pre_master_secret, self.client_random, self.server_random)
+        sec_params = tlsc.TLSSecurityParameters(cipher_suite, self.pre_master_secret, self.client_random,
+                                                self.server_random)
         self.assertEqual(sec_params.cipher_key_length, 16)
         self.assertEqual(sec_params.mac_key_length, SHA.digest_size)
         self.assertEqual(sec_params.iv_length, AES.block_size)
 
     def test_building_with_null_cipher_sets_lengths(self):
-        #RSA_WITH_NULL_MD5
+        # RSA_WITH_NULL_MD5
         cipher_suite = 0x1
-        sec_params = tlsc.TLSSecurityParameters(cipher_suite, self.pre_master_secret, self.client_random, self.server_random)
+        sec_params = tlsc.TLSSecurityParameters(cipher_suite, self.pre_master_secret, self.client_random,
+                                                self.server_random)
         self.assertEqual(sec_params.cipher_key_length, 0)
         self.assertEqual(sec_params.mac_key_length, MD5.digest_size)
         self.assertEqual(sec_params.iv_length, tlsc.NullCipher.block_size)
@@ -199,7 +214,8 @@ class TestTLSSecurityParameters(unittest.TestCase):
     def test_cleartext_message_matches_decrypted_message_with_block_cipher(self):
         # RSA_WITH_AES_128_CBC_SHA
         cipher_suite = 0x2f
-        sec_params = tlsc.TLSSecurityParameters(cipher_suite, self.pre_master_secret, self.client_random, self.server_random)
+        sec_params = tlsc.TLSSecurityParameters(cipher_suite, self.pre_master_secret, self.client_random,
+                                                self.server_random)
         self.assertEqual(sec_params.master_secret, self.master_secret)
         client_enc_cipher = sec_params.get_client_enc_cipher()
         client_dec_cipher = sec_params.get_client_dec_cipher()
@@ -210,7 +226,8 @@ class TestTLSSecurityParameters(unittest.TestCase):
     def test_cleartext_message_matches_decrypted_message_with_stream_cipher(self):
         # RSA_WITH_RC4_128_SHA
         cipher_suite = 0x5
-        sec_params = tlsc.TLSSecurityParameters(cipher_suite, self.pre_master_secret, self.client_random, self.server_random)
+        sec_params = tlsc.TLSSecurityParameters(cipher_suite, self.pre_master_secret, self.client_random,
+                                                self.server_random)
         self.assertEqual(sec_params.master_secret, self.master_secret)
         client_enc_cipher = sec_params.get_client_enc_cipher()
         client_dec_cipher = sec_params.get_client_dec_cipher()
@@ -220,7 +237,8 @@ class TestTLSSecurityParameters(unittest.TestCase):
     def test_hmac_used_matches_selected_ciphersuite(self):
         # RSA_WITH_3DES_EDE_CBC_SHA
         cipher_suite = 0xa
-        sec_params = tlsc.TLSSecurityParameters(cipher_suite, self.pre_master_secret, self.client_random, self.server_random)
+        sec_params = tlsc.TLSSecurityParameters(cipher_suite, self.pre_master_secret, self.client_random,
+                                                self.server_random)
         self.assertEqual(sec_params.master_secret, self.master_secret)
         client_enc_cipher = sec_params.get_client_enc_cipher()
         client_dec_cipher = sec_params.get_client_dec_cipher()
@@ -229,14 +247,16 @@ class TestTLSSecurityParameters(unittest.TestCase):
         self.assertEqual(client_dec_cipher.decrypt(client_enc_cipher.encrypt(plaintext)), plaintext)
         client_hmac = sec_params.get_client_hmac()
         client_hmac.update("some secret")
-        self.assertEqual(client_hmac.hexdigest(), HMAC.new(sec_params.client_write_MAC_key, "some secret", digestmod=SHA).hexdigest())
+        self.assertEqual(client_hmac.hexdigest(),
+                         HMAC.new(sec_params.client_write_MAC_key, "some secret", digestmod=SHA).hexdigest())
 
     def test_tls_1_1_and_above_iv_is_null(self):
         # RSA_WITH_AES_128_CBC_SHA
         cipher_suite = 0x2f
-        sec_params = tlsc.TLSSecurityParameters(cipher_suite, self.pre_master_secret, self.client_random, self.server_random, explicit_iv=True)
-        self.assertEqual(sec_params.client_write_IV, "\x00"*16)
-        self.assertEqual(sec_params.server_write_IV, "\x00"*16)
+        sec_params = tlsc.TLSSecurityParameters(cipher_suite, self.pre_master_secret, self.client_random,
+                                                self.server_random, explicit_iv=True)
+        self.assertEqual(sec_params.client_write_IV, "\x00" * 16)
+        self.assertEqual(sec_params.server_write_IV, "\x00" * 16)
 
     def test_load_rsa_privkey_from_pem_file(self):
         pem_file = env_local_file("openssl_1_0_1_f_server.pem")
@@ -245,8 +265,8 @@ class TestTLSSecurityParameters(unittest.TestCase):
         self.assertTrue(tls_ctx.crypto.server.rsa.privkey)
         self.assertTrue(tls_ctx.crypto.server.rsa.pubkey)
 
-class TestNullCompression(unittest.TestCase):
 
+class TestNullCompression(unittest.TestCase):
     def test_null_compression_returns_input_on_compress(self):
         null_compression = tlsc.NullCompression()
         input_ = "some text"
@@ -257,8 +277,8 @@ class TestNullCompression(unittest.TestCase):
         input_ = "some text"
         self.assertEqual(null_compression.decompress(input_), input_)
 
-class TestTLSCompressionParameters(unittest.TestCase):
 
+class TestTLSCompressionParameters(unittest.TestCase):
     def test_input_message_matches_decompressed_message_with_deflate(self):
         # DEFLATE
         compression_method = 0x1
@@ -273,8 +293,8 @@ class TestTLSCompressionParameters(unittest.TestCase):
         input_ = "some other text"
         self.assertEqual(comp_method.decompress(comp_method.compress(input_)), input_)
 
-class TestCryptoContainer(unittest.TestCase):
 
+class TestCryptoContainer(unittest.TestCase):
     def setUp(self):
         self._do_kex(tls.TLSVersion.TLS_1_0)
         unittest.TestCase.setUp(self)
@@ -322,12 +342,15 @@ xVgf/Neb/avXgIgi6drj8dp1fWA=
         self.cipher_suite = tls.TLSCipherSuite.RSA_WITH_AES_128_CBC_SHA
         # DEFLATE
         self.comp_method = tls.TLSCompressionMethod.NULL
-        self.client_hello = tls.TLSRecord(version=self.record_version)/tls.TLSHandshake()/tls.TLSClientHello(version=version, compression_methods=[self.comp_method], cipher_suites=[self.cipher_suite])
+        self.client_hello = tls.TLSRecord(version=self.record_version) / tls.TLSHandshake() / tls.TLSClientHello(
+            version=version, compression_methods=[self.comp_method], cipher_suites=[self.cipher_suite])
         self.tls_ctx.insert(self.client_hello)
-        self.server_hello = tls.TLSRecord(version=self.version)/tls.TLSHandshake()/tls.TLSServerHello(version=version, compression_method=self.comp_method, cipher_suite=self.cipher_suite)
+        self.server_hello = tls.TLSRecord(version=self.version) / tls.TLSHandshake() / tls.TLSServerHello(
+            version=version, compression_method=self.comp_method, cipher_suite=self.cipher_suite)
         self.tls_ctx.insert(self.server_hello)
         # Build method to generate EPMS automatically in TLSSessionCtx
-        self.client_kex = tls.TLSRecord(version=self.version)/tls.TLSHandshake()/tls.TLSClientKeyExchange(data=self.tls_ctx.get_encrypted_pms())
+        self.client_kex = tls.TLSRecord(version=self.version) / tls.TLSHandshake() / tls.TLSClientKeyExchange(
+            data=self.tls_ctx.get_encrypted_pms())
         self.tls_ctx.insert(self.client_kex)
 
     def test_crypto_container_increments_sequence_number(self):
@@ -349,12 +372,12 @@ xVgf/Neb/avXgIgi6drj8dp1fWA=
         self.assertEqual("%s%s%s%s" % (data, crypto_container.mac, padding, chr(len(padding))), str(crypto_container))
 
     def test_cipher_payload_is_block_size_aligned(self):
-        data = b"A"*1025
+        data = b"A" * 1025
         crypto_container = tlsc.CryptoContainer(self.tls_ctx, data)
         self.assertTrue(len(crypto_container) % AES.block_size == 0)
 
     def test_crypto_container_returns_ciphertext(self):
-        data = b"C"*102
+        data = b"C" * 102
         self.tls_ctx.client = False
         crypto_container = tlsc.CryptoContainer(self.tls_ctx, data)
         cleartext = str(crypto_container)
@@ -362,7 +385,7 @@ xVgf/Neb/avXgIgi6drj8dp1fWA=
         self.assertEqual(cleartext, self.tls_ctx.crypto.server.dec.decrypt(ciphertext))
 
     def test_generated_mac_can_be_overiden(self):
-        data = b"C"*102
+        data = b"C" * 102
         self.tls_ctx.client = False
         crypto_container = tlsc.CryptoContainer(self.tls_ctx, data)
         initial_mac = crypto_container.mac
@@ -370,7 +393,7 @@ xVgf/Neb/avXgIgi6drj8dp1fWA=
         self.assertNotEqual(initial_mac, crypto_container.mac)
 
     def test_tls_1_1_and_above_has_a_random_explicit_iv_with_block_cipher(self):
-        data = b"C"*102
+        data = b"C" * 102
         self._do_kex(tls.TLSVersion.TLS_1_1)
         crypto_container = tlsc.CryptoContainer(self.tls_ctx, data)
         self.assertNotEqual(crypto_container.explicit_iv, "")
@@ -378,10 +401,53 @@ xVgf/Neb/avXgIgi6drj8dp1fWA=
         self.assertTrue(str(crypto_container).startswith(crypto_container.explicit_iv))
 
     def test_tls_1_0_and_below_has_no_explicit_iv(self):
-        data = b"C"*102
+        data = b"C" * 102
         crypto_container = tlsc.CryptoContainer(self.tls_ctx, data)
         self.assertEqual(crypto_container.explicit_iv, "")
         self.assertTrue(str(crypto_container).startswith(data))
+
+
+class TestTLSPRF(unittest.TestCase):
+
+    def _initialize_tls1_known_params(self):
+        self.pms = binascii.unhexlify(
+            "03010555c6b01b9e47d803058dc33fe49175064811b06192bb40a0b732b99b5fe5fdc113b5520dcb7fc97bb43aadd231")
+        self.ms = binascii.unhexlify(
+            "f59ea7a04a13483ee024096840b3d3b8fb2c5a9cddf205f148790469b165421caacd5b32743265090307f6479170c248")
+        self.client_random = binascii.unhexlify("55b1285b1332a91c75b9822135f3cb729c9a62f30ce296032a872719092df119")
+        self.server_random = binascii.unhexlify("0774c311aa283e218d4c0d20561829fda850d92d022a4bdb56bc185ea4e2a5a3")
+        # SHA1 - 20 bytes
+        self.client_mac = binascii.unhexlify("6a88b5e508875c425200c38f9110840ea0fc7cf5")
+        # AES - 16 bytes
+        self.client_key = binascii.unhexlify("53606e034295c9ccd50d84d60d8fea9c")
+        self.client_iv = binascii.unhexlify("4ffdf70f8dbdd6dcebb1b246cbb4a36b")
+        # SHA1 - 20 bytes
+        self.server_mac = binascii.unhexlify("9042c763e49a6876173a0837d47263bce4da5703")
+        # AES - 16 bytes
+        self.server_key = binascii.unhexlify("95c4ee054377d9e7006a8da970e95630")
+        self.server_iv = binascii.unhexlify("4f4f168ced384533cb47cfdf3ecaf3ef")
+
+    def test_tls1_1_prf_against_static_data(self):
+        self._initialize_tls1_known_params()
+        prf = tlsc.TLSPRF(SHA256)
+        self.assertEqual(prf.prf_numbytes(self.pms, tlsc.TLSPRF.TLS_MD_MASTER_SECRET_CONST,
+                                          "%s%s" % (self.client_random, self.server_random), 48), self.ms)
+        crypto_material_len = len(self.client_mac) + len(self.client_key) + len(self.client_iv)
+        crypto_material = prf.prf_numbytes(self.ms, tlsc.TLSPRF.TLS_MD_KEY_EXPANSION_CONST,
+                                           "%s%s" % (self.server_random, self.client_random), 2 * crypto_material_len)
+        i = 0
+        self.assertEqual(self.client_mac, crypto_material[i:len(self.client_mac)])
+        i += len(self.client_mac)
+        self.assertEqual(self.server_mac, crypto_material[i:i + len(self.server_mac)])
+        i += len(self.server_mac)
+        self.assertEqual(self.client_key, crypto_material[i:i + len(self.client_key)])
+        i += len(self.client_key)
+        self.assertEqual(self.server_key, crypto_material[i:i + len(self.server_key)])
+        i += len(self.server_key)
+        self.assertEqual(self.client_iv, crypto_material[i:i + len(self.client_iv)])
+        i += len(self.client_iv)
+        self.assertEqual(self.server_iv, crypto_material[i:i + len(self.server_iv)])
+        i += len(self.server_iv)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
- Made the required PRF changes
- Modified the verify_data generation
- Added unitests for PRFs

Gave it a quick spin, and I can speak TLS 1.2 to both openssl and Java, as well as a bunch of sites.