### PR TITLE
Human readable FieldListField for Enum type list entries

### DIFF
--- a/scapy_ssl_tls/ssl_tls.py
+++ b/scapy_ssl_tls/ssl_tls.py
@@ -112,6 +112,11 @@ class XBEnumField(BEnumField):
     def i2repr(self, pkt, x):
         return lhex(self.i2h(pkt, x))   
 
+class ReprFieldListField(FieldListField):
+    ''' Human Readable FieldListField for Enum type list entries '''
+    def i2repr(self, pkt, x):
+        return self.field.i2repr(pkt,x)
+
 class StrConditionalField(ConditionalField):
     '''
     Base conditional field that is not restricted to pkt checks
@@ -372,14 +377,14 @@ class TLSExtECPointsFormat(PacketNoPadding):
     name = "TLS Extension EC Points Format"
     fields_desc = [
                    XFieldLenField("length", None, length_of="ec_point_formats", fmt="B"),
-                   FieldListField("ec_point_formats", None, ByteEnumField("ec_point_format", None, TLS_EC_POINT_FORMATS), length_from=lambda x:x.length),
+                   ReprFieldListField("ec_point_formats", None, ByteEnumField("ec_point_format", None, TLS_EC_POINT_FORMATS), length_from=lambda x:x.length),
                   ]
 
 class TLSExtEllipticCurves(PacketNoPadding):
     name = "TLS Extension Elliptic Curves"
     fields_desc = [
                    XFieldLenField("length", None, length_of="elliptic_curves", fmt="H"),
-                   FieldListField("elliptic_curves", None, ShortEnumField("elliptic_curve", None, TLS_ELLIPTIC_CURVES), length_from=lambda x:x.length),
+                   ReprFieldListField("elliptic_curves", None, ShortEnumField("elliptic_curve", None, TLS_ELLIPTIC_CURVES), length_from=lambda x:x.length),
                   ]
     
 class TLSSignatureHashAlgorithm(PacketNoPadding):
@@ -422,10 +427,10 @@ class TLSClientHello(Packet):
                    StrLenField("session_id", '', length_from=lambda x:x.session_id_length),
     
                    XFieldLenField("cipher_suites_length", None, length_of="cipher_suites", fmt="H"),
-                   FieldListField("cipher_suites", [TLSCipherSuite.RSA_WITH_AES_128_CBC_SHA], XShortEnumField("cipher", None, TLS_CIPHER_SUITES), length_from=lambda x:x.cipher_suites_length),
+                   ReprFieldListField("cipher_suites", [TLSCipherSuite.RSA_WITH_AES_128_CBC_SHA], XShortEnumField("cipher", None, TLS_CIPHER_SUITES), length_from=lambda x:x.cipher_suites_length),
                    
                    XFieldLenField("compression_methods_length", None, length_of="compression_methods", fmt="B"),
-                   FieldListField("compression_methods", [TLSCompressionMethod.NULL], ByteEnumField("compression", None, TLS_COMPRESSION_METHODS), length_from=lambda x:x.compression_methods_length),
+                   ReprFieldListField("compression_methods", [TLSCompressionMethod.NULL], ByteEnumField("compression", None, TLS_COMPRESSION_METHODS), length_from=lambda x:x.compression_methods_length),
                    
                    StrConditionalField(XFieldLenField("extensions_length", None, length_of="extensions", fmt="H"), lambda pkt,s,val: True if val or pkt.extensions or (s and struct.unpack("!H",s[:2])[0]==len(s)-2) else False),
                    PacketListField("extensions", None, TLSExtension, length_from=lambda x:x.extensions_length),
@@ -633,10 +638,10 @@ class DTLSClientHello(Packet):
                    StrLenField("cookie", '', length_from=lambda x:x.cookie_length),
                    
                    XFieldLenField("cipher_suites_length", None, length_of="cipher_suites", fmt="H"),
-                   FieldListField("cipher_suites", None, XShortEnumField("cipher", None, TLS_CIPHER_SUITES), length_from=lambda x:x.cipher_suites_length),
+                   ReprFieldListField("cipher_suites", None, XShortEnumField("cipher", None, TLS_CIPHER_SUITES), length_from=lambda x:x.cipher_suites_length),
                    
                    XFieldLenField("compression_methods_length", None, length_of="compression_methods", fmt="B"),
-                   FieldListField("compression_methods", None, ByteEnumField("compression", None, TLS_COMPRESSION_METHODS), length_from=lambda x:x.compression_methods_length),
+                   ReprFieldListField("compression_methods", None, ByteEnumField("compression", None, TLS_COMPRESSION_METHODS), length_from=lambda x:x.compression_methods_length),
                    
                    StrConditionalField(XFieldLenField("extensions_length", None, length_of="extensions", fmt="H"), lambda pkt,s,val: True if val or pkt.extensions or (s and struct.unpack("!H",s[:2])[0]==len(s)-2) else False),
                    PacketListField("extensions", None, TLSExtension, length_from=lambda x:x.extensions_length),
@@ -687,7 +692,7 @@ class SSLv2ClientHello(Packet):
                    XFieldLenField("session_id_length", None, length_of="session_id", fmt="H"),
                    XFieldLenField("challenge_length", None, length_of="challenge", fmt="H"),
                    
-                   FieldListField("cipher_suites", None, XBEnumField("cipher", None, SSLv2_CIPHER_SUITES, fmt="!I", numbytes=3), length_from=lambda x:x.cipher_suites_length),
+                   ReprFieldListField("cipher_suites", None, XBEnumField("cipher", None, SSLv2_CIPHER_SUITES, fmt="!I", numbytes=3), length_from=lambda x:x.cipher_suites_length),
                    StrLenField("session_id", '', length_from=lambda x:x.session_id_length),
                    StrLenField("challenge", '', length_from=lambda x:x.challenge_length),
                    ]
@@ -704,7 +709,7 @@ class SSLv2ServerHello(Packet):
                    XFieldLenField("connection_id_length", None, length_of="connection_id", fmt="H"),
                    
                    StrLenField("certificates", '', length_from=lambda x:x.certificates_length),
-                   FieldListField("cipher_suites", None, XBEnumField("cipher", None, SSLv2_CIPHER_SUITES, fmt="!I", numbytes=3), length_from=lambda x:x.cipher_suites_length),
+                   ReprFieldListField("cipher_suites", None, XBEnumField("cipher", None, SSLv2_CIPHER_SUITES, fmt="!I", numbytes=3), length_from=lambda x:x.cipher_suites_length),
                    StrLenField("connection_id", '', length_from=lambda x:x.connection_id_length),
                    ]
 


### PR DESCRIPTION
ssl.show() used to display machine representation for FieldListFields containing EnumFields. ReprFieldListField properly creates a human readable representation of the field list.

advantage: readability
disadvantage: long lines 


### current

        ###[ SSL/TLS ]###
          \records   \
           |###[ TLS Record ]###
           |  content_type= handshake
           |  version   = TLS_1_0
           |  length    = 0x200
           |###[ TLS Handshake ]###
           |     type      = client_hello
           |     length    = 0x1fc
           |###[ TLS Client Hello ]###
           |        version   = TLS_1_2
           |        gmt_unix_time= 120678007
           |        random_bytes= "Ua\xc1\\w22\xc4\x01s\x8d>\xc0\xd2\xa6\xe2\xb7#4*]#\xaf\x003\xa3'\xa0"
           |        session_id_length= 0x0
           |        session_id= ''
           |        cipher_suites_length= 0x76
           |        cipher_suites= [49200, 49196, 49192, 49188, 49172, 49162, 163, 159, 107, 106, 57, 56, 136, 135, 49202, 49198, 49194, 49190, 49167, 49157, 157, 61, 53, 132, 49199, 49195, 49191, 49187, 49171, 49161, 162, 158, 103, 64, 51, 50, 154, 153, 69, 68, 49201, 49197, 49193, 49189, 49166, 49156, 156, 60, 47, 150, 65, 49170, 49160, 22, 19, 49165, 49155, 10, 255]
           |        compression_methods_length= 0x1
           |        compression_methods= [0]
           |        extensions_length= 0x15d
           |        \extensions\
           |         |###[ TLS Extension ]###
           |         |  type      = ec_point_formats
           |         |  length    = 0x4
           |         |###[ TLS Extension EC Points Format ]###
           |         |     length    = 0x3
           |         |     ec_point_formats= [0, 1, 2]
           |         |###[ TLS Extension ]###
           |         |  type      = supported_groups
           |         |  length    = 0x34
           |         |###[ TLS Extension Elliptic Curves ]###
           |         |     length    = 0x32
           |         |     elliptic_curves= [14, 13, 25, 11, 12, 24, 9, 10, 22, 23, 8, 6, 7, 20, 21, 4, 5, 18, 19, 1, 2, 3, 15, 16, 17]

### new (check ciphers, compressions, elliptic curves)

        ###[ SSL/TLS ]###
          \records   \
           |###[ TLS Record ]###
           |  content_type= handshake
           |  version   = TLS_1_0
           |  length    = 0x200
           |###[ TLS Handshake ]###
           |     type      = client_hello
           |     length    = 0x1fc
           |###[ TLS Client Hello ]###
           |        version   = TLS_1_2
           |        gmt_unix_time= 120678007
           |        random_bytes= "Ua\xc1\\w22\xc4\x01s\x8d>\xc0\xd2\xa6\xe2\xb7#4*]#\xaf\x003\xa3'\xa0"
           |        session_id_length= 0x0
           |        session_id= ''
           |        cipher_suites_length= 0x76
           |        cipher_suites= ['ECDHE_RSA_WITH_AES_256_GCM_SHA384', 'ECDHE_ECDSA_WITH_AES_256_GCM_SHA384', 'ECDHE_RSA_WITH_AES_256_CBC_SHA384', 'ECDHE_ECDSA_WITH_AES_256_CBC_SHA384', 'ECDHE_RSA_WITH_AES_256_CBC_SHA', 'ECDHE_ECDSA_WITH_AES_256_CBC_SHA', 'DHE_DSS_WITH_AES_256_GCM_SHA384', 'DHE_RSA_WITH_AES_256_GCM_SHA384', 'DHE_RSA_WITH_AES_256_CBC_SHA256', 'DHE_DSS_WITH_AES_256_CBC_SHA256', 'DHE_RSA_WITH_AES_256_CBC_SHA', 'DHE_DSS_WITH_AES_256_CBC_SHA', 'DHE_RSA_WITH_CAMELLIA_256_CBC_SHA', 'DHE_DSS_WITH_CAMELLIA_256_CBC_SHA', 'ECDH_RSA_WITH_AES_256_GCM_SHA384', 'ECDH_ECDSA_WITH_AES_256_GCM_SHA384', 'ECDH_RSA_WITH_AES_256_CBC_SHA384', 'ECDH_ECDSA_WITH_AES_256_CBC_SHA384', 'ECDH_RSA_WITH_AES_256_CBC_SHA', 'ECDH_ECDSA_WITH_AES_256_CBC_SHA', 'RSA_WITH_AES_256_GCM_SHA384', 'RSA_WITH_AES_256_CBC_SHA256', 'RSA_WITH_AES_256_CBC_SHA', 'RSA_WITH_CAMELLIA_256_CBC_SHA', 'ECDHE_RSA_WITH_AES_128_GCM_SHA256', 'ECDHE_ECDSA_WITH_AES_128_GCM_SHA256', 'ECDHE_RSA_WITH_AES_128_CBC_SHA256', 'ECDHE_ECDSA_WITH_AES_128_CBC_SHA256', 'ECDHE_RSA_WITH_AES_128_CBC_SHA', 'ECDHE_ECDSA_WITH_AES_128_CBC_SHA', 'DHE_DSS_WITH_AES_128_GCM_SHA256', 'DHE_RSA_WITH_AES_128_GCM_SHA256', 'DHE_RSA_WITH_AES_128_CBC_SHA256', 'DHE_DSS_WITH_AES_128_CBC_SHA256', 'DHE_RSA_WITH_AES_128_CBC_SHA', 'DHE_DSS_WITH_AES_128_CBC_SHA', 'DHE_RSA_WITH_SEED_CBC_SHA', 'DHE_DSS_WITH_SEED_CBC_SHA', 'DHE_RSA_WITH_CAMELLIA_128_CBC_SHA', 'DHE_DSS_WITH_CAMELLIA_128_CBC_SHA', 'ECDH_RSA_WITH_AES_128_GCM_SHA256', 'ECDH_ECDSA_WITH_AES_128_GCM_SHA256', 'ECDH_RSA_WITH_AES_128_CBC_SHA256', 'ECDH_ECDSA_WITH_AES_128_CBC_SHA256', 'ECDH_RSA_WITH_AES_128_CBC_SHA', 'ECDH_ECDSA_WITH_AES_128_CBC_SHA', 'RSA_WITH_AES_128_GCM_SHA256', 'RSA_WITH_AES_128_CBC_SHA256', 'RSA_WITH_AES_128_CBC_SHA', 'RSA_WITH_SEED_CBC_SHA', 'RSA_WITH_CAMELLIA_128_CBC_SHA', 'ECDHE_RSA_WITH_3DES_EDE_CBC_SHA', 'ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA', 'DHE_RSA_WITH_3DES_EDE_CBC_SHA', 'DHE_DSS_WITH_3DES_EDE_CBC_SHA', 'ECDH_RSA_WITH_3DES_EDE_CBC_SHA', 'ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA', 'RSA_WITH_3DES_EDE_CBC_SHA', 'EMPTY_RENEGOTIATION_INFO_SCSV']
           |        compression_methods_length= 0x1
           |        compression_methods= ['NULL']
           |        extensions_length= 0x15d
           |        \extensions\
           |         |###[ TLS Extension ]###
           |         |  type      = ec_point_formats
           |         |  length    = 0x4
           |         |###[ TLS Extension EC Points Format ]###
           |         |     length    = 0x3
           |         |     ec_point_formats= ['uncompressed', 'ansiX962_compressed_prime', 'ansiX962_compressed_char2']
           |         |###[ TLS Extension ]###
           |         |  type      = supported_groups
           |         |  length    = 0x34
           |         |###[ TLS Extension Elliptic Curves ]###
           |         |     length    = 0x32
           |         |     elliptic_curves= ['sect571r1', 'sect571k1', 'secp521r1', 'sect409k1', 'sect409r1', 'secp384r1', 'sect283k1', 'sect283r1', 'secp256k1', 'secp256r1', 'sect239k1', 'sect233k1', 'sect233r1', 'secp224k1', 'secp224r1', 'sect193r1', 'sect193r2', 'secp192k1', 'secp192r1', 'sect163k1', 'sect163r1', 'sect163r2', 'secp160k1', 'secp160r1', 'secp160r2']
