### PR TITLE
ECDHE client support

### DIFF
--- a/examples/full_rsa_connection_with_application_data.py
+++ b/examples/full_rsa_connection_with_application_data.py
@@ -9,32 +9,37 @@ import sys
 
 try:
     # This import works from the project directory
-    basedir = os.path.abspath(os.path.join(os.path.dirname(__file__),"../"))
+    basedir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))
     sys.path.append(basedir)
     from scapy_ssl_tls.ssl_tls import *
 except ImportError:
     # If you installed this package via pip, you just need to execute this
     from scapy.layers.ssl_tls import *
 
-tls_version = TLSVersion.TLS_1_1
+tls_version = TLSVersion.TLS_1_2
+
 
 def tls_hello(sock):
-    client_hello = TLSRecord(version=tls_version)/TLSHandshake()/TLSClientHello(version=tls_version, compression_methods=(TLSCompressionMethod.NULL),
-#                                                                             cipher_suites=(TLSCipherSuite.RSA_WITH_AES_128_CBC_SHA))
-#                                                                             cipher_suites=(TLSCipherSuite.RSA_WITH_RC4_128_SHA))
-                                                                            cipher_suites=(TLSCipherSuite.DHE_RSA_WITH_AES_128_CBC_SHA))
-#                                                                             cipher_suites=(TLSCipherSuite.DHE_DSS_WITH_AES_128_CBC_SHA))
+    client_hello = TLSRecord(version=tls_version) / TLSHandshake() /\
+                   TLSClientHello(version=tls_version, compression_methods=[TLSCompressionMethod.NULL, ],
+                                  cipher_suites=[TLSCipherSuite.ECDHE_RSA_WITH_AES_128_CBC_SHA256, ])
+                                  # cipher_suites=[TLSCipherSuite.RSA_WITH_AES_128_CBC_SHA, ])
+                                  # cipher_suites=[TLSCipherSuite.RSA_WITH_RC4_128_SHA, ])
+                                  # cipher_suites=[TLSCipherSuite.DHE_RSA_WITH_AES_128_CBC_SHA, ])
+                                  # cipher_suites=[TLSCipherSuite.DHE_DSS_WITH_AES_128_CBC_SHA, ])
     sock.sendall(client_hello)
     server_hello = sock.recvall()
     server_hello.show()
 
+
 def tls_client_key_exchange(sock):
-    client_key_exchange = TLSRecord(version=tls_version)/TLSHandshake()/TLSClientKeyExchange(data=sock.tls_ctx.get_client_kex_data())
-    client_ccs = TLSRecord(version=tls_version)/TLSChangeCipherSpec()
+    client_key_exchange = TLSRecord(version=tls_version) / TLSHandshake() / sock.tls_ctx.get_client_kex_data()
+    client_ccs = TLSRecord(version=tls_version) / TLSChangeCipherSpec()
     sock.sendall(TLS.from_records([client_key_exchange, client_ccs]))
     sock.sendall(to_raw(TLSFinished(), sock.tls_ctx))
     server_finished = sock.recvall()
     server_finished.show()
+
 
 def tls_client(ip, priv_key=None):
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -57,8 +62,8 @@ def tls_client(ip, priv_key=None):
         sock.close()
 
 if __name__ == "__main__":
-    if len(sys.argv)>2:
-        server = (sys.argv[1],int(sys.argv[2]))
+    if len(sys.argv) > 2:
+        server = (sys.argv[1], int(sys.argv[2]))
     else:
         server = ("127.0.0.1", 8443)
     tls_client(server)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pycrypto>=2.6
 scapy>=2.2.0
+tinyec>=0.3.1

--- a/scapy_ssl_tls/ssl_tls.py
+++ b/scapy_ssl_tls/ssl_tls.py
@@ -514,11 +514,32 @@ class TLSKeyExchange(Packet):
         return next_layer
 
 
-class TLSClientKeyExchange(TLSKeyExchange):
-    name = "TLS Client Key Exchange"
+class TLSClientRSAParams(PacketNoPayload):
+    name = "TLS RSA Client Params"
     # Length field needs to be removed for SSL3 compatibility. I don't care for now
     fields_desc = [XFieldLenField("length", None, length_of="data", fmt="!H"),
                    StrLenField("data", "", length_from=lambda x:x.length)]
+
+
+class TLSClientDHParams(PacketNoPayload):
+    name = "TLS Diffie-Hellman Client Params"
+    # Length field needs to be removed for SSL3 compatibility. I don't care for now
+    fields_desc = [XFieldLenField("length", None, length_of="data", fmt="!H"),
+                   StrLenField("data", "", length_from=lambda x:x.length)]
+
+
+class TLSClientECDHParams(PacketNoPayload):
+    name = "TLS EC Diffie-Hellman Client Params"
+    # Another brilliant TLS idea. Let's hold ECDHE param length on 1 byte instead of 2
+    fields_desc = [XFieldLenField("length", None, length_of="data", fmt="!B"),
+                   StrLenField("data", "", length_from=lambda x:x.length)]
+
+
+class TLSClientKeyExchange(TLSKeyExchange):
+    name = "TLS Client Key Exchange"
+    kex_payload_table = {TLSKexNames.RSA: TLSClientRSAParams,
+                         TLSKexNames.DHE: TLSClientDHParams,
+                         TLSKexNames.ECDHE: TLSClientECDHParams}
 
 
 class TLSServerDHParams(PacketNoPayload):

--- a/scapy_ssl_tls/ssl_tls.py
+++ b/scapy_ssl_tls/ssl_tls.py
@@ -266,7 +266,10 @@ TLSTypeBoolean = EnumStruct(TLS_TYPE_BOOLEAN)
 
 TLS_EC_POINT_FORMATS = registry.EC_POINT_FORMAT_REGISTRY
 TLSEcPointFormat = EnumStruct(TLS_EC_POINT_FORMATS)
-    
+
+TLS_EC_CURVE_TYPES = registry.EC_CURVE_TYPE_REGISTRY
+TLSECCurveTypes = EnumStruct(TLS_EC_CURVE_TYPES)
+
 TLS_ELLIPTIC_CURVES = registry.SUPPORTED_GROUPS_REGISTRY
 TLSEllipticCurve = EnumStruct(TLS_ELLIPTIC_CURVES)
 
@@ -485,6 +488,7 @@ class TLSClientKeyExchange(PacketNoPayload):
     fields_desc = [ XFieldLenField("length", None, length_of="data", fmt="!H"),
                     StrLenField("data", "", length_from=lambda x:x.length) ]
 
+
 class TLSServerDHParams(PacketNoPayload):
     name = "TLS Diffie-Hellman Server Params"
     fields_desc = [XFieldLenField("p_length", None, length_of="p", fmt="!H"),
@@ -494,14 +498,27 @@ class TLSServerDHParams(PacketNoPayload):
                    XFieldLenField("ys_length", None, length_of="y_s", fmt="!H"),
                    StrLenField("y_s", "", length_from=lambda x:x.ys_length),
                    XFieldLenField("sig_length", None, length_of="sig", fmt="!H"),
-                   StrLenField("sig", '', length_from=lambda x:x.sig_length) ]
+                   StrLenField("sig", '', length_from=lambda x:x.sig_length)]
+
+
+class TLSServerECDHParams(PacketNoPayload):
+    name = "TLS EC Diffie-Hellman Server Params"
+    fields_desc = [ByteEnumField("curve_type", TLSECCurveTypes.NAMED_CURVE, TLS_EC_CURVE_TYPES),
+                   ShortEnumField("curve_name", TLSEllipticCurve.SECP256R1, TLS_ELLIPTIC_CURVES),
+                   XFieldLenField("p_length", None, length_of="p", fmt="!B"),
+                   StrLenField("p", '', length_from=lambda x:x.p_length),
+                   ByteEnumField("hash_type", TLSHashAlgorithm.SHA256, TLS_HASH_ALGORITHMS),
+                   ByteEnumField("sig_type", TLSSignatureAlgorithm.RSA, TLS_SIGNATURE_ALGORITHMS),
+                   XFieldLenField("sig_length", None, length_of="sig", fmt="!H"),
+                   StrLenField("sig", '', length_from=lambda x:x.sig_length)]
+
 
 class TLSServerKeyExchange(Packet):
     name = "TLS Server Key Exchange"
 
-    kex_payload_table = { TLSKexNames.DHE: TLSServerDHParams,
-                          #Add ECDHE, and ERSA in the future
-                         }
+    kex_payload_table = {TLSKexNames.DHE: TLSServerDHParams,
+                         TLSKexNames.ECDHE: TLSServerECDHParams}
+                          #Add ERSA in the future
 
     def __init__(self, *args, **fields):
         try:

--- a/scapy_ssl_tls/ssl_tls.py
+++ b/scapy_ssl_tls/ssl_tls.py
@@ -479,47 +479,10 @@ class TLSHeartBeat(PacketNoPayload):
     fields_desc = [ByteEnumField("type", TLSHeartbeatMessageType.HEARTBEAT_REQUEST, TLS_HEARTBEAT_MESSAGE_TYPE),
                   FieldLenField("length", None, length_of="data", fmt="H"),
                   StrLenField("data", "", length_from=lambda x:x.length),
-                  StrLenField("padding", "", length_from=lambda x: 'P' * (16 - x.length)),
-                  ]
-
-class TLSClientKeyExchange(PacketNoPayload):
-    name = "TLS Client Key Exchange"
-    # Length field needs to be removed for SSL3 compatibility. I don't care for now
-    fields_desc = [ XFieldLenField("length", None, length_of="data", fmt="!H"),
-                    StrLenField("data", "", length_from=lambda x:x.length) ]
+                  StrLenField("padding", "", length_from=lambda x: 'P' * (16 - x.length))]
 
 
-class TLSServerDHParams(PacketNoPayload):
-    name = "TLS Diffie-Hellman Server Params"
-    fields_desc = [XFieldLenField("p_length", None, length_of="p", fmt="!H"),
-                   StrLenField("p", '', length_from=lambda x:x.p_length),
-                   XFieldLenField("g_length", None, length_of="g", fmt="!H"),
-                   StrLenField("g", '', length_from=lambda x:x.g_length),
-                   XFieldLenField("ys_length", None, length_of="y_s", fmt="!H"),
-                   StrLenField("y_s", "", length_from=lambda x:x.ys_length),
-                   XFieldLenField("sig_length", None, length_of="sig", fmt="!H"),
-                   StrLenField("sig", '', length_from=lambda x:x.sig_length)]
-
-
-class TLSServerECDHParams(PacketNoPayload):
-    name = "TLS EC Diffie-Hellman Server Params"
-    fields_desc = [ByteEnumField("curve_type", TLSECCurveTypes.NAMED_CURVE, TLS_EC_CURVE_TYPES),
-                   ShortEnumField("curve_name", TLSEllipticCurve.SECP256R1, TLS_ELLIPTIC_CURVES),
-                   XFieldLenField("p_length", None, length_of="p", fmt="!B"),
-                   StrLenField("p", '', length_from=lambda x:x.p_length),
-                   ByteEnumField("hash_type", TLSHashAlgorithm.SHA256, TLS_HASH_ALGORITHMS),
-                   ByteEnumField("sig_type", TLSSignatureAlgorithm.RSA, TLS_SIGNATURE_ALGORITHMS),
-                   XFieldLenField("sig_length", None, length_of="sig", fmt="!H"),
-                   StrLenField("sig", '', length_from=lambda x:x.sig_length)]
-
-
-class TLSServerKeyExchange(Packet):
-    name = "TLS Server Key Exchange"
-
-    kex_payload_table = {TLSKexNames.DHE: TLSServerDHParams,
-                         TLSKexNames.ECDHE: TLSServerECDHParams}
-                          #Add ERSA in the future
-
+class TLSKeyExchange(Packet):
     def __init__(self, *args, **fields):
         try:
             self.tls_ctx = fields["ctx"]
@@ -549,6 +512,45 @@ class TLSServerKeyExchange(Packet):
                 except KeyError:
                     pass
         return next_layer
+
+
+class TLSClientKeyExchange(TLSKeyExchange):
+    name = "TLS Client Key Exchange"
+    # Length field needs to be removed for SSL3 compatibility. I don't care for now
+    fields_desc = [XFieldLenField("length", None, length_of="data", fmt="!H"),
+                   StrLenField("data", "", length_from=lambda x:x.length)]
+
+
+class TLSServerDHParams(PacketNoPayload):
+    name = "TLS Diffie-Hellman Server Params"
+    fields_desc = [XFieldLenField("p_length", None, length_of="p", fmt="!H"),
+                   StrLenField("p", '', length_from=lambda x:x.p_length),
+                   XFieldLenField("g_length", None, length_of="g", fmt="!H"),
+                   StrLenField("g", '', length_from=lambda x:x.g_length),
+                   XFieldLenField("ys_length", None, length_of="y_s", fmt="!H"),
+                   StrLenField("y_s", "", length_from=lambda x:x.ys_length),
+                   XFieldLenField("sig_length", None, length_of="sig", fmt="!H"),
+                   StrLenField("sig", '', length_from=lambda x:x.sig_length)]
+
+
+class TLSServerECDHParams(PacketNoPayload):
+    name = "TLS EC Diffie-Hellman Server Params"
+    fields_desc = [ByteEnumField("curve_type", TLSECCurveTypes.NAMED_CURVE, TLS_EC_CURVE_TYPES),
+                   ShortEnumField("curve_name", TLSEllipticCurve.SECP256R1, TLS_ELLIPTIC_CURVES),
+                   XFieldLenField("p_length", None, length_of="p", fmt="!B"),
+                   StrLenField("p", '', length_from=lambda x:x.p_length),
+                   ByteEnumField("hash_type", TLSHashAlgorithm.SHA256, TLS_HASH_ALGORITHMS),
+                   ByteEnumField("sig_type", TLSSignatureAlgorithm.RSA, TLS_SIGNATURE_ALGORITHMS),
+                   XFieldLenField("sig_length", None, length_of="sig", fmt="!H"),
+                   StrLenField("sig", '', length_from=lambda x:x.sig_length)]
+
+
+class TLSServerKeyExchange(TLSKeyExchange):
+    name = "TLS Server Key Exchange"
+    kex_payload_table = {TLSKexNames.DHE: TLSServerDHParams,
+                         TLSKexNames.ECDHE: TLSServerECDHParams}
+                          #Add ERSA in the future
+
 
 class TLSFinished(PacketNoPayload):
     name = "TLS Handshake Finished"

--- a/scapy_ssl_tls/ssl_tls_crypto.py
+++ b/scapy_ssl_tls/ssl_tls_crypto.py
@@ -141,6 +141,10 @@ class TLSSessionCtx(object):
         self.crypto.client.dh = namedtuple("dh", ["x", "y_c"])
         self.crypto.client.dh.x = None
         self.crypto.client.dh.y_c = None
+        self.crypto.client.ecdh = namedtuple("ecdh", ["curve_name", "priv", "pub"])
+        self.crypto.client.ecdh.curve_name = None
+        self.crypto.client.ecdh.priv = None
+        self.crypto.client.ecdh.pub = None
         self.crypto.server = namedtuple('server', ['enc','dec','rsa', "hmac"])
         self.crypto.server.enc = None
         self.crypto.server.dec = None
@@ -156,6 +160,10 @@ class TLSSessionCtx(object):
         self.crypto.server.dh.g = None
         self.crypto.server.dh.x = None
         self.crypto.server.dh.y_s = None
+        self.crypto.server.ecdh = namedtuple("ecdh", ["curve_name", "priv", "pub"])
+        self.crypto.server.ecdh.curve_name = None
+        self.crypto.server.ecdh.priv = None
+        self.crypto.server.ecdh.pub = None
         self.crypto.session = namedtuple('session', ["encrypted_premaster_secret",
                                                      'premaster_secret',
                                                      'master_secret',
@@ -209,12 +217,19 @@ class TLSSessionCtx(object):
                   "crypto-server-dsa-pubkey":repr(self.crypto.server.dsa.pubkey),
                   "crypto-server-dsa-privkey":repr(self.crypto.server.dsa.privkey),
 
-                  "crypto-client-dh-x":repr(self.crypto.client.dh.x),
-                  "crypto-client-dh-y_c":repr(self.crypto.client.dh.y_c),
-                  "crypto-server-dh-p":repr(self.crypto.server.dh.p),
-                  "crypto-server-dh-g":repr(self.crypto.server.dh.g),
-                  "crypto-server-dh-x":repr(self.crypto.server.dh.x),
-                  "crypto-server-dh-y_s":repr(self.crypto.server.dh.y_s),
+                  "crypto-client-dh-x": repr(self.crypto.client.dh.x),
+                  "crypto-client-dh-y_c": repr(self.crypto.client.dh.y_c),
+                  "crypto-server-dh-p": repr(self.crypto.server.dh.p),
+                  "crypto-server-dh-g": repr(self.crypto.server.dh.g),
+                  "crypto-server-dh-x": repr(self.crypto.server.dh.x),
+                  "crypto-server-dh-y_s": repr(self.crypto.server.dh.y_s),
+
+                  "crypto-client-ecdh-curve_name": repr(self.crypto.client.ecdh.curve_name),
+                  "crypto-client-ecdh-priv": repr(self.crypto.client.ecdh.priv),
+                  "crypto-client-ecdh-pub": repr(self.crypto.client.ecdh.pub),
+                  "crypto-server-ecdh-curve_name": repr(self.crypto.server.ecdh.curve_name),
+                  "crypto-server-ecdh-priv": repr(self.crypto.server.ecdh.priv),
+                  "crypto-server-ecdh-pub": repr(self.crypto.server.ecdh.pub),
 
                   'crypto-session-encrypted_premaster_secret':repr(self.crypto.session.encrypted_premaster_secret),
                   'crypto-session-premaster_secret':repr(self.crypto.session.premaster_secret),
@@ -259,12 +274,19 @@ class TLSSessionCtx(object):
         str_ +="\n\t crypto.server.dsa.privkey=%(crypto-server-dsa-privkey)s"
         str_ +="\n\t crypto.server.dsa.pubkey=%(crypto-server-dsa-pubkey)s"
 
-        str_ +="\n\t crypto.client.dh.x=%(crypto-client-dh-x)s"
-        str_ +="\n\t crypto.client.dh.y_c=%(crypto-client-dh-y_c)s"
-        str_ +="\n\t crypto.server.dh.p=%(crypto-server-dh-p)s"
-        str_ +="\n\t crypto.server.dh.g=%(crypto-server-dh-g)s"
-        str_ +="\n\t crypto.server.dh.x=%(crypto-server-dh-x)s"
-        str_ +="\n\t crypto.server.dh.y_s=%(crypto-server-dh-y_s)s"
+        str_ += "\n\t crypto.client.dh.x=%(crypto-client-dh-x)s"
+        str_ += "\n\t crypto.client.dh.y_c=%(crypto-client-dh-y_c)s"
+        str_ += "\n\t crypto.server.dh.p=%(crypto-server-dh-p)s"
+        str_ += "\n\t crypto.server.dh.g=%(crypto-server-dh-g)s"
+        str_ += "\n\t crypto.server.dh.x=%(crypto-server-dh-x)s"
+        str_ += "\n\t crypto.server.dh.y_s=%(crypto-server-dh-y_s)s"
+
+        str_ += "\n\t crypto.client.ecdh.curve_name=%(crypto-client-ecdh-curve_name)s"
+        str_ += "\n\t crypto.client.ecdh.priv=%(crypto-client-ecdh-priv)s"
+        str_ += "\n\t crypto.client.ecdh.pub=%(crypto-client-ecdh-pub)s"
+        str_ += "\n\t crypto.server.ecdh.curve_name=%(crypto-server-ecdh-curve_name)s"
+        str_ += "\n\t crypto.server.ecdh.priv=%(crypto-server-ecdh-priv)s"
+        str_ += "\n\t crypto.server.ecdh.pub=%(crypto-server-ecdh-pub)s"
 
         str_ +="\n\t crypto.session.encrypted_premaster_secret=%(crypto-session-encrypted_premaster_secret)s"
         str_ +="\n\t crypto.session.premaster_secret=%(crypto-session-premaster_secret)s"
@@ -370,6 +392,9 @@ class TLSSessionCtx(object):
                     self.crypto.server.dh.p = p[tls.TLSServerDHParams].p
                     self.crypto.server.dh.g = p[tls.TLSServerDHParams].g
                     self.crypto.server.dh.y_s = p[tls.TLSServerDHParams].y_s
+                if p.haslayer(tls.TLSServerECDHParams):
+                    self.crypto.server.ecdh.curve_name = p[tls.TLSServerECDHParams].curve_name
+                    self.crypto.server.ecdh.pub = p[tls.TLSServerECDHParams].p
 
             # calculate key material
             if p.haslayer(tls.TLSClientKeyExchange):
@@ -380,6 +405,9 @@ class TLSSessionCtx(object):
                         self.crypto.session.premaster_secret = self.crypto.server.rsa.privkey.decrypt(self.crypto.session.encrypted_premaster_secret, None)
                 elif self.params.negotiated.key_exchange == tls.TLSKexNames.DHE:
                     self.crypto.client.dh.y_c = p[tls.TLSClientKeyExchange].data
+                elif self.params.negotiated.key_exchange == tls.TLSKexNames.ECDHE:
+                    # Skip the length byte
+                    self.crypto.client.ecdh.pub = p[tls.TLSClientKeyExchange].data[1:]
 
                 explicit_iv = True if self.params.negotiated.version > tls.TLSVersion.TLS_1_0 else False
                 self.sec_params = TLSSecurityParameters(self.crypto.session.prf,
@@ -444,7 +472,7 @@ class TLSSessionCtx(object):
             raise ValueError("Cannot calculate encrypted MS. No server certificate found in connection")
         return self.crypto.session.encrypted_premaster_secret
 
-    def get_client_dh_pubkey(self, x=None):
+    def get_client_dh_pubkey(self, priv_key=None):
         # ValueError is propagated to caller both if hex or int conversion fail
         import math
         import random
@@ -460,7 +488,7 @@ class TLSSessionCtx(object):
         # Long story short, this provides 128bits of key space (sqrt(2**256)). TLS leaves this up to the implementation.
         # Another option is to gather random.randint(0, 2**nb_bits(p) - 1), but has little added security
         # In our case, since we don't care about security, it really doesn't matter what we pick
-        a = x or random.randint(0, 2**256 - 1)
+        a = priv_key or random.randint(0, 2**256 - 1)
         self.crypto.client.dh.x = int_to_str(a)
         self.crypto.client.dh.y_c = int_to_str(pow(g, a, p))
         # Per RFC 4346 section 8.1.2
@@ -469,11 +497,16 @@ class TLSSessionCtx(object):
         self.crypto.session.premaster_secret = int_to_str(pow(y_s, a, p)).lstrip("\x00")
         return self.crypto.client.dh.y_c
 
+    def get_client_ecdh_pubkey(self, priv_key=None):
+        raise NotImplementedError("EC key exchange not fully supported yet")
+
     def get_client_kex_data(self, val=None):
         if self.params.negotiated.key_exchange == tls.TLSKexNames.RSA:
             return self.get_encrypted_pms(val)
         elif self.params.negotiated.key_exchange == tls.TLSKexNames.DHE:
             return self.get_client_dh_pubkey(val)
+        elif self.params.negotiated.key_exchange == tls.TLSKexNames.ECDHE:
+            return self.get_client_ecdh_pubkey(val)
         else:
             raise NotImplementedError("Key exchange unknown or currently not supported")
 

--- a/scapy_ssl_tls/ssl_tls_crypto.py
+++ b/scapy_ssl_tls/ssl_tls_crypto.py
@@ -17,7 +17,7 @@ import tinyec.registry as ec_reg
 
 from collections import namedtuple
 from Crypto.Cipher import AES, ARC2, ARC4, DES, DES3, PKCS1_v1_5
-from Crypto.Hash import HMAC, MD5, SHA, SHA256
+from Crypto.Hash import HMAC, MD5, SHA, SHA256, SHA384
 from Crypto.PublicKey import DSA, RSA
 from Crypto.Util.asn1 import DerSequence
 from scapy.asn1.asn1 import ASN1_SEQUENCE
@@ -745,6 +745,10 @@ class ECDHE(DH):
     pass
 
 
+class ECDSA(object):
+    pass
+
+
 class TLSSecurityParameters(object):
     
     crypto_params = {
@@ -780,18 +784,36 @@ class TLSSecurityParameters(object):
             tls.TLSCipherSuite.DHE_DSS_EXPORT1024_WITH_DES_CBC_SHA: {"name":tls.TLS_CIPHER_SUITES[0x0063], "export":True, "key_exchange":{"type":DHE, "name":tls.TLSKexNames.DHE, "sig":DSA}, "cipher":{"type":DES, "name":"DES", "key_len":8, "mode":DES.MODE_CBC, "mode_name":"CBC"}, "hash":{"type":SHA, "name":"SHA"}},
             tls.TLSCipherSuite.DHE_DSS_EXPORT1024_WITH_RC4_56_SHA:  {"name":tls.TLS_CIPHER_SUITES[0x0065], "export":True, "key_exchange":{"type":DHE, "name":tls.TLSKexNames.DHE, "sig":DSA}, "cipher":{"type":ARC4, "name":"RC4", "key_len":8, "mode":None, "mode_name":"Stream"}, "hash":{"type":SHA, "name":"SHA"}},
             tls.TLSCipherSuite.DHE_DSS_WITH_RC4_128_SHA:            {"name":tls.TLS_CIPHER_SUITES[0x0066], "export":False, "key_exchange":{"type":DHE, "name":tls.TLSKexNames.DHE, "sig":DSA}, "cipher":{"type":ARC4, "name":"RC4", "key_len":16, "mode":None, "mode_name":"Stream"}, "hash":{"type":SHA, "name":"SHA"}},
+            tls.TLSCipherSuite.ECDHE_ECDSA_WITH_NULL_SHA:   {"name":tls.TLS_CIPHER_SUITES[0xc006], "export":False, "key_exchange":{"type":ECDHE, "name":tls.TLSKexNames.ECDHE, "sig":ECDSA}, "cipher":{"type":NullCipher, "name":"Null", "key_len":0, "mode":None, "mode_name":""}, "hash":{"type":SHA, "name":"SHA"}},
+            tls.TLSCipherSuite.ECDHE_ECDSA_WITH_RC4_128_SHA:   {"name":tls.TLS_CIPHER_SUITES[0xc007], "export":False, "key_exchange":{"type":ECDHE, "name":tls.TLSKexNames.ECDHE, "sig":ECDSA}, "cipher":{"type":ARC4, "name":"RC4", "key_len":16, "mode":None, "mode_name":"Stream"}, "hash":{"type":SHA, "name":"SHA"}},
+            tls.TLSCipherSuite.ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA:   {"name":tls.TLS_CIPHER_SUITES[0xc008], "export":False, "key_exchange":{"type":ECDHE, "name":tls.TLSKexNames.ECDHE, "sig":ECDSA}, "cipher":{"type":DES3, "name":"DES3", "key_len":8, "mode":DES.MODE_CBC, "mode_name":"CBC"}, "hash":{"type":SHA, "name":"SHA"}},
+            tls.TLSCipherSuite.ECDHE_ECDSA_WITH_AES_128_CBC_SHA:   {"name":tls.TLS_CIPHER_SUITES[0xc009], "export":False, "key_exchange":{"type":ECDHE, "name":tls.TLSKexNames.ECDHE, "sig":ECDSA}, "cipher":{"type":AES, "name":"AES", "key_len":16, "mode":AES.MODE_CBC, "mode_name":"CBC"}, "hash":{"type":SHA, "name":"SHA"}},
+            tls.TLSCipherSuite.ECDHE_ECDSA_WITH_AES_256_CBC_SHA:   {"name":tls.TLS_CIPHER_SUITES[0xc00a], "export":False, "key_exchange":{"type":ECDHE, "name":tls.TLSKexNames.ECDHE, "sig":ECDSA}, "cipher":{"type":AES, "name":"AES", "key_len":32, "mode":AES.MODE_CBC, "mode_name":"CBC"}, "hash":{"type":SHA, "name":"SHA"}},
+            tls.TLSCipherSuite.ECDHE_RSA_WITH_NULL_SHA:   {"name":tls.TLS_CIPHER_SUITES[0xc010], "export":False, "key_exchange":{"type":ECDHE, "name":tls.TLSKexNames.ECDHE, "sig":RSA}, "cipher":{"type":NullCipher, "name":"Null", "key_len":0, "mode":None, "mode_name":""}, "hash":{"type":SHA, "name":"SHA"}},
+            tls.TLSCipherSuite.ECDHE_RSA_WITH_RC4_128_SHA:   {"name":tls.TLS_CIPHER_SUITES[0xc011], "export":False, "key_exchange":{"type":ECDHE, "name":tls.TLSKexNames.ECDHE, "sig":RSA}, "cipher":{"type":ARC4, "name":"RC4", "key_len":16, "mode":None, "mode_name":"Stream"}, "hash":{"type":SHA, "name":"SHA"}},
+            tls.TLSCipherSuite.ECDHE_RSA_WITH_3DES_EDE_CBC_SHA:   {"name":tls.TLS_CIPHER_SUITES[0xc012], "export":False, "key_exchange":{"type":ECDHE, "name":tls.TLSKexNames.ECDHE, "sig":RSA}, "cipher":{"type":DES3, "name":"DES3", "key_len":8, "mode":DES.MODE_CBC, "mode_name":"CBC"}, "hash":{"type":SHA, "name":"SHA"}},
+            tls.TLSCipherSuite.ECDHE_RSA_WITH_AES_128_CBC_SHA:   {"name":tls.TLS_CIPHER_SUITES[0xc013], "export":False, "key_exchange":{"type":ECDHE, "name":tls.TLSKexNames.ECDHE, "sig":RSA}, "cipher":{"type":AES, "name":"AES", "key_len":16, "mode":AES.MODE_CBC, "mode_name":"CBC"}, "hash":{"type":SHA, "name":"SHA"}},
+            tls.TLSCipherSuite.ECDHE_RSA_WITH_AES_256_CBC_SHA:   {"name":tls.TLS_CIPHER_SUITES[0xc014], "export":False, "key_exchange":{"type":ECDHE, "name":tls.TLSKexNames.ECDHE, "sig":RSA}, "cipher":{"type":AES, "name":"AES", "key_len":32, "mode":AES.MODE_CBC, "mode_name":"CBC"}, "hash":{"type":SHA, "name":"SHA"}},
+            tls.TLSCipherSuite.ECDHE_ECDSA_WITH_AES_128_CBC_SHA256:   {"name":tls.TLS_CIPHER_SUITES[0xc023], "export":False, "key_exchange":{"type":ECDHE, "name":tls.TLSKexNames.ECDHE, "sig":ECDSA}, "cipher":{"type":AES, "name":"AES", "key_len":16, "mode":AES.MODE_CBC, "mode_name":"CBC"}, "hash":{"type":SHA256, "name":"SHA256"}},
+            tls.TLSCipherSuite.ECDHE_ECDSA_WITH_AES_256_CBC_SHA384:   {"name":tls.TLS_CIPHER_SUITES[0xc024], "export":False, "key_exchange":{"type":ECDHE, "name":tls.TLSKexNames.ECDHE, "sig":ECDSA}, "cipher":{"type":AES, "name":"AES", "key_len":32, "mode":AES.MODE_CBC, "mode_name":"CBC"}, "hash":{"type":SHA384, "name":"SHA384"}},
             tls.TLSCipherSuite.ECDHE_RSA_WITH_AES_128_CBC_SHA256:   {"name":tls.TLS_CIPHER_SUITES[0xc027], "export":False, "key_exchange":{"type":ECDHE, "name":tls.TLSKexNames.ECDHE, "sig":RSA}, "cipher":{"type":AES, "name":"AES", "key_len":16, "mode":AES.MODE_CBC, "mode_name":"CBC"}, "hash":{"type":SHA256, "name":"SHA256"}},
+            tls.TLSCipherSuite.ECDHE_RSA_WITH_AES_256_CBC_SHA384:   {"name":tls.TLS_CIPHER_SUITES[0xc028], "export":False, "key_exchange":{"type":ECDHE, "name":tls.TLSKexNames.ECDHE, "sig":RSA}, "cipher":{"type":AES, "name":"AES", "key_len":16, "mode":AES.MODE_CBC, "mode_name":"CBC"}, "hash":{"type":SHA384, "name":"SHA384"}},
+
             # 0x0087: DHE_DSS_WITH_CAMELLIA_256_CBC_SHA => Camelia support should use camcrypt or the camelia patch for pycrypto
             # 0x0088: DHE_RSA_WITH_CAMELLIA_256_CBC_SHA => Camelia support should use camcrypt or the camelia patch for pycrypto
             }
-# Unsupported for now, until TLS1.2 and ECDHE support implemented
-#         ECDH_ECDSA_WITH_AES_256_CBC_SHA = 0xc005
-#         ECDHE_ECDSA_WITH_AES_256_CBC_SHA = 0xc00a
-#         ECDH_RSA_WITH_AES_256_CBC_SHA = 0xc00f    
-#         ECDHE_RSA_WITH_AES_256_CBC_SHA = 0xc014
+# Unsupported for now, until GCM/CCM and SRP are integrated
 #         SRP_SHA_RSA_WITH_AES_256_CBC_SHA = 0xc021
 #         SRP_SHA_DSS_WITH_AES_256_CBC_SHA = 0xc022
 #         TLS_FALLBACK_SCSV = 0x5600
+#     0xc02b: 'ECDHE_ECDSA_WITH_AES_128_GCM_SHA256',
+#     0xc02c: 'ECDHE_ECDSA_WITH_AES_256_GCM_SHA384',
+#     0xc02f: 'ECDHE_RSA_WITH_AES_128_GCM_SHA256',
+#     0xc030: 'ECDHE_RSA_WITH_AES_256_GCM_SHA384',
+#     0xc0ac: 'ECDHE_ECDSA_WITH_AES_128_CCM',
+#     0xc0ad: 'ECDHE_ECDSA_WITH_AES_256_CCM',
+#     0xc0ae: 'ECDHE_ECDSA_WITH_AES_128_CCM_8',
+#     0xc0af: 'ECDHE_ECDSA_WITH_AES_256_CCM_8',
 
     def __init__(self, prf, cipher_suite, pms, client_random, server_random, explicit_iv=False):
         """ /!\ This class is not thread safe

--- a/scapy_ssl_tls/ssl_tls_crypto.py
+++ b/scapy_ssl_tls/ssl_tls_crypto.py
@@ -441,7 +441,6 @@ class TLSSessionCtx(object):
                     self.crypto.client.dh.y_c = p[tls.TLSClientDHParams].data
                 elif p.haslayer(tls.TLSClientECDHParams):
                     ec_curve = ec_reg.get_curve(self.crypto.server.ecdh.curve_name)
-                    # Skip the length byte, before ANSI parsing
                     self.crypto.client.ecdh.pub = str_to_ec_point(p[tls.TLSClientECDHParams].data, ec_curve)
 
                 explicit_iv = True if self.params.negotiated.version > tls.TLSVersion.TLS_1_0 else False

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ def _post_install(dir_):
                     print(line, end="")
 
 def os_install_requires():
-    dependencies = ["scapy", "pycrypto"]
+    dependencies = ["scapy", "pycrypto", "tinyec"]
     # Scapy on OSX requires dnet and pcapy, but fails to declare them as dependencies
     if platform.system() == "Darwin":
         dependencies.extend(("dnet", "pcapy"))

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ setup(
     long_description=read("README.rst") if os.path.isfile("README.rst") else read("README.md"),
     install_requires=os_install_requires(),
     test_suite="nose.collector",
-    tests_require=["nose", "scapy", "pycrypto"],
+    tests_require=["nose", "scapy", "pycrypto", "tinyec"],
     # Change once virtualenv bug is fixed
     # data_files = get_layer_files_dst(sites=site.getsitepackages())
     data_files=get_layer_files_dst(get_site_packages()),

--- a/tests/test_ssl_tls.py
+++ b/tests/test_ssl_tls.py
@@ -17,31 +17,36 @@ from scapy.layers.inet import IP, TCP
 
 
 def env_local_file(file):
-    return os.path.join(os.path.dirname(__file__),'files',file)
+    return os.path.join(os.path.dirname(__file__), 'files', file)
+
 
 class TestTLSRecord(unittest.TestCase):
-
     def setUp(self):
-        self.server_hello = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSServerHello()
-        self.cert_list = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSCertificateList()
-        self.server_hello_done = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSServerHelloDone()
+        self.server_hello = tls.TLSRecord() / tls.TLSHandshake() / tls.TLSServerHello()
+        self.cert_list = tls.TLSRecord() / tls.TLSHandshake() / tls.TLSCertificateList()
+        self.server_hello_done = tls.TLSRecord() / tls.TLSHandshake() / tls.TLSServerHelloDone()
         self.stacked_pkt = tls.TLS.from_records([self.server_hello, self.cert_list, self.server_hello_done])
         # issue 28
         der_cert = '0\x82\x03\xe70\x82\x02\xcf\xa0\x03\x02\x01\x02\x02\t\x00\xb9\xee\xd4\xd9U\xa5\x9e\xb30\r\x06\t*\x86H\x86\xf7\r\x01\x01\x05\x05\x000p1\x0b0\t\x06\x03U\x04\x06\x13\x02UK1\x160\x14\x06\x03U\x04\n\x0c\rOpenSSL Group1"0 \x06\x03U\x04\x0b\x0c\x19FOR TESTING PURPOSES ONLY1%0#\x06\x03U\x04\x03\x0c\x1cOpenSSL Test Intermediate CA0\x1e\x17\r111208140148Z\x17\r211016140148Z0d1\x0b0\t\x06\x03U\x04\x06\x13\x02UK1\x160\x14\x06\x03U\x04\n\x0c\rOpenSSL Group1"0 \x06\x03U\x04\x0b\x0c\x19FOR TESTING PURPOSES ONLY1\x190\x17\x06\x03U\x04\x03\x0c\x10Test Server Cert0\x82\x01"0\r\x06\t*\x86H\x86\xf7\r\x01\x01\x01\x05\x00\x03\x82\x01\x0f\x000\x82\x01\n\x02\x82\x01\x01\x00\xf3\x84\xf3\x926\xdc\xb2F\xcafz\xe5)\xc5\xf3I("\xd3\xb9\xfe\xe0\xde\xe48\xce\xee"\x1c\xe9\x91;\x94\xd0r/\x87\x85YKf\xb1\xc5\xf5z\x85]\xc2\x0f\xd3.)X6\xccHk\xa2\xa2\xb5&\xceg\xe2G\xb6\xdfI\xd2?\xfa\xa2\x10\xb7\xc2\x97D~\x874mm\xf2\x8b\xb4U+\xd6!\xdeSK\x90\xea\xfd\xea\xf985+\xf4\xe6\x9a\x0e\xf6\xbb\x12\xab\x87!\xc3/\xbc\xf4\x06\xb8\x8f\x8e\x10\x07\'\x95\xe5B\xcb\xd1\xd5\x10\x8c\x92\xac\xee\x0f\xdc#H\x89\xc9\xc6\x93\x0c"\x02\xe7t\xe7%\x00\xab\xf8\x0f\\\x10\xb5\x85;f\x94\xf0\xfbMW\x06U!"%\xdb\xf3\xaa\xa9`\xbfM\xaay\xd1\xab\x92H\xba\x19\x8e\x12\xech\xd9\xc6\xba\xdf\xecZ\x1c\xd8C\xfe\xe7R\xc9\xcf\x02\xd0\xc7\x7f\xc9~\xb0\x94\xe3SDX\x0b.\xfd)t\xb5\x06\x9b\\D\x8d\xfb2u\xa4:\xa8g{\x872\nP\x8d\xe1\xa2\x13J%\xaf\xe6\x1c\xb1%\xbf\xb4\x99\xa2S\xd3\xa2\x02\xbf\x11\x02\x03\x01\x00\x01\xa3\x81\x8f0\x81\x8c0\x0c\x06\x03U\x1d\x13\x01\x01\xff\x04\x020\x000\x0e\x06\x03U\x1d\x0f\x01\x01\xff\x04\x04\x03\x02\x05\xe00,\x06\t`\x86H\x01\x86\xf8B\x01\r\x04\x1f\x16\x1dOpenSSL Generated Certificate0\x1d\x06\x03U\x1d\x0e\x04\x16\x04\x14\x82\xbc\xcf\x00\x00\x13\xd1\xf79%\x9a\'\xe7\xaf\xd2\xef \x1bn\xac0\x1f\x06\x03U\x1d#\x04\x180\x16\x80\x146\xc3l\x88\xe7\x95\xfe\xb0\xbd\xec\xce>=\x86\xab!\x81\x87\xda\xda0\r\x06\t*\x86H\x86\xf7\r\x01\x01\x05\x05\x00\x03\x82\x01\x01\x00\xa9\xbdMW@t\xfe\x96\xe9+\xd6x\xfd\xb3c\xcc\xf4\x0bM\x12\xcaZt\x8d\x9b\xf2a\xe6\xfd\x06\x11C\x84\xfc\x17\xa0\xeccc6\xb9\x9e6j\xb1\x02Zj[?j\xa1\xea\x05e\xac~@\x1aHe\x88\xd19M\xd3Kw\xe9\xc8\xbb+\x9eZ\xf4\x0849G\xb9\x02\x081\x9a\xf1\xd9\x17\xc5\xe9\xa6\xa5\x96Km@\xa9[e(\xcb\xcb\x00\x03\x82c7\xd3\xad\xb1\x96;v\xf5\x17\x16\x02{\xbdSSFr4\xd6\x08d\x9d\xbbC\xfbd\xb1I\x07w\tazB\x17\x110\x0c\xd9\'\\\xf5q\xb6\xf0\x180\xf3~\xf1\x85?2~J\xaf\xb3\x10\xf7l\xc6\x85K-\'\xad\n \\\xfb\x8d\x19p4\xb9u_|\x87\xd5\xc3\xec\x93\x13A\xfcs\x03\xb9\x8d\x1a\xfe\xf7&\x86I\x03\xa9\xc5\x82?\x80\r)I\xb1\x8f\xed$\x1b\xfe\xcfX\x90F\xe7\xa8\x87\xd4\x1ey\xef\x99m\x18\x9f>\x8b\x82\x07\xc1C\xc7\xe0%\xb6\xf1\xd3\x00\xd7@\xabK\x7f+z>\xa6\x99LT'
-        stacked_handshake_layers = [tls.TLSHandshake()/tls.TLSServerHello(),
-                                    tls.TLSHandshake()/tls.TLSCertificateList(certificates=[tls.TLSCertificate(data=x509.X509Cert(der_cert))]),
-                                    tls.TLSHandshake()/tls.TLSServerHelloDone()]
-        self.stacked_handshake = tls.TLS(str(tls.TLSRecord(content_type="handshake")/"".join(list(map(str,stacked_handshake_layers)))))
+        stacked_handshake_layers = [tls.TLSHandshake() / tls.TLSServerHello(),
+                                    tls.TLSHandshake() / tls.TLSCertificateList(
+                                        certificates=[tls.TLSCertificate(data=x509.X509Cert(der_cert))]),
+                                    tls.TLSHandshake() / tls.TLSServerHelloDone()]
+        self.stacked_handshake = tls.TLS(
+            str(tls.TLSRecord(content_type="handshake") / "".join(list(map(str, stacked_handshake_layers)))))
         unittest.TestCase.setUp(self)
 
     def test_pkt_built_from_stacked_tls_records_is_identical(self):
         self.assertEqual(len(str(self.server_hello)), len(str(self.stacked_pkt.records[0])))
         self.assertEqual(len(str(self.cert_list)), len(str(self.stacked_pkt.records[1])))
         self.assertEqual(len(str(self.server_hello_done)), len(str(self.stacked_pkt.records[2])))
-        self.assertEqual(len(str(self.server_hello)) - len(tls.TLSRecord()), self.stacked_pkt.records[0][tls.TLSRecord].length)
-        self.assertEqual(len(str(self.cert_list)) - len(tls.TLSRecord()), self.stacked_pkt.records[1][tls.TLSRecord].length)
-        self.assertEqual(len(str(self.server_hello_done)) - len(tls.TLSRecord()), self.stacked_pkt.records[2][tls.TLSRecord].length)
-        
+        self.assertEqual(len(str(self.server_hello)) - len(tls.TLSRecord()),
+                         self.stacked_pkt.records[0][tls.TLSRecord].length)
+        self.assertEqual(len(str(self.cert_list)) - len(tls.TLSRecord()),
+                         self.stacked_pkt.records[1][tls.TLSRecord].length)
+        self.assertEqual(len(str(self.server_hello_done)) - len(tls.TLSRecord()),
+                         self.stacked_pkt.records[2][tls.TLSRecord].length)
+
     def test_pkt_built_from_stacked_tls_handshakes_is_identical(self):
         # issue #28
         # layers are present
@@ -52,20 +57,21 @@ class TestTLSRecord(unittest.TestCase):
         self.assertTrue(self.stacked_handshake.haslayer(tls.TLSCertificate))
         self.assertTrue(self.stacked_handshake.haslayer(tls.TLSServerHelloDone))
         # check TLS layers one by one
-        self.assertEqual(re.findall(r'<(TLS[\w]+)',str(repr(self.stacked_handshake))), ['TLSRecord', 'TLSHandshake', 'TLSServerHello',
-                                                                                        'TLSHandshake', 'TLSCertificateList', 'TLSCertificate',
-                                                                                        'TLSHandshake', 'TLSServerHelloDone'])
+        self.assertEqual(re.findall(r'<(TLS[\w]+)', str(repr(self.stacked_handshake))),
+                         ['TLSRecord', 'TLSHandshake', 'TLSServerHello',
+                          'TLSHandshake', 'TLSCertificateList', 'TLSCertificate',
+                          'TLSHandshake', 'TLSServerHelloDone'])
 
     def test_fragmentation_fails_on_non_aligned_boundary_for_handshakes(self):
-        pkt = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSClientHello()
+        pkt = tls.TLSRecord() / tls.TLSHandshake() / tls.TLSClientHello()
         with self.assertRaises(tls.TLSFragmentationError):
             pkt.fragment(7)
         self.assertIsInstance(pkt.fragment(8), tls.TLS)
 
     def test_fragmenting_a_record_returns_a_list_of_records_when_fragment_size_is_smaller_than_record(self):
         frag_size = 3
-        app_data = "A"*7
-        pkt = tls.TLSRecord(version=tls.TLSVersion.TLS_1_1, content_type=tls.TLSContentType.APPLICATION_DATA)/app_data
+        app_data = "A" * 7
+        pkt = tls.TLSRecord(version=tls.TLSVersion.TLS_1_1, content_type=tls.TLSContentType.APPLICATION_DATA) / app_data
         fragments = pkt.fragment(frag_size)
         self.assertEqual(len(fragments.records), len(app_data) / frag_size + len(app_data) % frag_size)
         record_length = len(tls.TLSRecord())
@@ -75,41 +81,49 @@ class TestTLSRecord(unittest.TestCase):
         self.assertEqual(len(fragments.records[2]), record_length + (len(app_data) % frag_size))
 
     def test_fragmenting_a_record_does_nothing_when_fragment_size_is_larger_than_record(self):
-        app_data = "A"*7
+        app_data = "A" * 7
         frag_size = len(app_data)
-        pkt = tls.TLSRecord(version=tls.TLSVersion.TLS_1_1, content_type=tls.TLSContentType.APPLICATION_DATA)/app_data
+        pkt = tls.TLSRecord(version=tls.TLSVersion.TLS_1_1, content_type=tls.TLSContentType.APPLICATION_DATA) / app_data
         self.assertEqual(str(pkt), str(pkt.fragment(frag_size)))
         frag_size = len(app_data) * 2
         self.assertEqual(str(pkt), str(pkt.fragment(frag_size)))
 
     def test_large_record_payload_is_not_fragmented_when_smaller_then_max_ushort(self):
-        app_data = "A"*tls.TLSRecord.MAX_LEN
-        pkt = tls.TLSRecord(version=tls.TLSVersion.TLS_1_1, content_type=tls.TLSContentType.APPLICATION_DATA)/app_data
+        app_data = "A" * tls.TLSRecord.MAX_LEN
+        pkt = tls.TLSRecord(version=tls.TLSVersion.TLS_1_1, content_type=tls.TLSContentType.APPLICATION_DATA) / app_data
         try:
             str(pkt)
         except tls.TLSFragmentationError:
             self.fail()
 
     def test_large_record_payload_is_fragmented_when_above_max_ushort(self):
-        app_data = "A"*(tls.TLSRecord.MAX_LEN + 1)
-        pkt = tls.TLSRecord(version=tls.TLSVersion.TLS_1_1, content_type=tls.TLSContentType.APPLICATION_DATA)/app_data
+        app_data = "A" * (tls.TLSRecord.MAX_LEN + 1)
+        pkt = tls.TLSRecord(version=tls.TLSVersion.TLS_1_1, content_type=tls.TLSContentType.APPLICATION_DATA) / app_data
         with self.assertRaises(tls.TLSFragmentationError):
             str(pkt)
 
-class TestTLSDissector(unittest.TestCase):
 
+class TestTLSDissector(unittest.TestCase):
     def setUp(self):
-        self.payload = binascii.unhexlify("160301004a02000046030155514d08929c06119d291bae09ec50ba48f52069c840673c76721aa5c53bc352202de1c20c707ba9b083282d2eba3d95bdfb5847eb9241f252173a04c9f990d508002f0016030104080b0004040004010003fe308203fa308202e2a003020102020900980ceed2480234b2300d06092a864886f70d0101050500305b310b3009060355040613025553311330110603550408130a43616c69666f726e696131173015060355040a130e4369747269782053797374656d73311e301c06035504031315616d73736c2e656e672e636974726974652e6e6574301e170d3135303432343233313435395a170d3235303432313233313435395a305b310b3009060355040613025553311330110603550408130a43616c69666f726e696131173015060355040a130e4369747269782053797374656d73311e301c06035504031315616d73736c2e656e672e636974726974652e6e657430820122300d06092a864886f70d01010105000382010f003082010a0282010100c0e2f8d4d4423ef7ce3e6ea789ad83c831fd679a8745bfe7d3628a544b7f04fec8bb8eb72737a6334764b68e796fbd70f19a1754776aba2f5d9685f2931b57456825ca75baca540c34de26115037d76d1a6fabbab6cd666af98fcb6b9c2fc714fd523828babae067f9ad7da51100306b4a5783a1402a4d80524dc14d0867f526e055dbd32e6f9f785072d72b8c36994bb56c2cdbf74e2149e7c625fed1c6405e205289c2b4608bd28704303764227f4540b95054c115be9185223b8a815462818090c6c933ce4c39d4049197106fe84918048adfd185fc7d64167804ccafbae8b84dc81d0288f4078c736a4ccc04c27184ffb45b14b4bd79ab472dba8877c20f0203010001a381c03081bd301d0603551d0e041604141979840d258e11dad71d942fe77e567fc0bbb48430818d0603551d2304818530818280141979840d258e11dad71d942fe77e567fc0bbb484a15fa45d305b310b3009060355040613025553311330110603550408130a43616c69666f726e696131173015060355040a130e4369747269782053797374656d73311e301c06035504031315616d73736c2e656e672e636974726974652e6e6574820900980ceed2480234b2300c0603551d13040530030101ff300d06092a864886f70d010105050003820101006fbd05d20b74d33b727fb2ccfebf3f36950278631bf87e77f503ce8e9a080925b6276f32218cadd0a43d40d89ba0e5fd9897ac536a079440385ba59e2593100df52224a8f8b786561466558d435d9ea5e4f320028ee7afa005f09b64b16f3e6b787af31b28d623edd480a50dd64fc6f0da0eab0c38c5d8965504c9c3d5c2c85514b7b1f8df9ee2d9116ac05781dbef26a66e98679f84b0378a1f8857f69e72cf72c11e836e0144153bd412dcfb506ed9e4a6181208b92be3ba9ec13f3c5b19eb700884e04a051603f2f2302d542e094afcce6694c5e46452a486b9ba339578e0f530f98824872eef62a23d685e9710c47362a034b699b7f9e1521b135e1e950d16030100040e000000")
+        self.payload = binascii.unhexlify(
+            "160301004a02000046030155514d08929c06119d291bae09ec50ba48f52069c840673c76721aa5c53bc352202de1c20c707ba9b083282d2eba3d95bdfb5847eb9241f252173a04c9f990d508002f0016030104080b0004040004010003fe308203fa308202e2a003020102020900980ceed2480234b2300d06092a864886f70d0101050500305b310b3009060355040613025553311330110603550408130a43616c69666f726e696131173015060355040a130e4369747269782053797374656d73311e301c06035504031315616d73736c2e656e672e636974726974652e6e6574301e170d3135303432343233313435395a170d3235303432313233313435395a305b310b3009060355040613025553311330110603550408130a43616c69666f726e696131173015060355040a130e4369747269782053797374656d73311e301c06035504031315616d73736c2e656e672e636974726974652e6e657430820122300d06092a864886f70d01010105000382010f003082010a0282010100c0e2f8d4d4423ef7ce3e6ea789ad83c831fd679a8745bfe7d3628a544b7f04fec8bb8eb72737a6334764b68e796fbd70f19a1754776aba2f5d9685f2931b57456825ca75baca540c34de26115037d76d1a6fabbab6cd666af98fcb6b9c2fc714fd523828babae067f9ad7da51100306b4a5783a1402a4d80524dc14d0867f526e055dbd32e6f9f785072d72b8c36994bb56c2cdbf74e2149e7c625fed1c6405e205289c2b4608bd28704303764227f4540b95054c115be9185223b8a815462818090c6c933ce4c39d4049197106fe84918048adfd185fc7d64167804ccafbae8b84dc81d0288f4078c736a4ccc04c27184ffb45b14b4bd79ab472dba8877c20f0203010001a381c03081bd301d0603551d0e041604141979840d258e11dad71d942fe77e567fc0bbb48430818d0603551d2304818530818280141979840d258e11dad71d942fe77e567fc0bbb484a15fa45d305b310b3009060355040613025553311330110603550408130a43616c69666f726e696131173015060355040a130e4369747269782053797374656d73311e301c06035504031315616d73736c2e656e672e636974726974652e6e6574820900980ceed2480234b2300c0603551d13040530030101ff300d06092a864886f70d010105050003820101006fbd05d20b74d33b727fb2ccfebf3f36950278631bf87e77f503ce8e9a080925b6276f32218cadd0a43d40d89ba0e5fd9897ac536a079440385ba59e2593100df52224a8f8b786561466558d435d9ea5e4f320028ee7afa005f09b64b16f3e6b787af31b28d623edd480a50dd64fc6f0da0eab0c38c5d8965504c9c3d5c2c85514b7b1f8df9ee2d9116ac05781dbef26a66e98679f84b0378a1f8857f69e72cf72c11e836e0144153bd412dcfb506ed9e4a6181208b92be3ba9ec13f3c5b19eb700884e04a051603f2f2302d542e094afcce6694c5e46452a486b9ba339578e0f530f98824872eef62a23d685e9710c47362a034b699b7f9e1521b135e1e950d16030100040e000000")
         unittest.TestCase.setUp(self)
 
     def _static_tls_handshake(self):
         # Setup static parameters, so PRF output is reproducible
         tls_ctx = tlsc.TLSSessionCtx()
-        tls_ctx.crypto.session.premaster_secret = "\x03\x01" + "C"*46
-        client_hello = tls.TLSRecord(version="TLS_1_0")/tls.TLSHandshake()/tls.TLSClientHello(version="TLS_1_0", gmt_unix_time=1234, random_bytes="A"*28, session_id="", compression_methods=[0],
-                                                                                              cipher_suites=(tls.TLSCipherSuite.RSA_WITH_AES_128_CBC_SHA))
+        tls_ctx.crypto.session.premaster_secret = "\x03\x01" + "C" * 46
+        client_hello = tls.TLSRecord(version="TLS_1_0") / tls.TLSHandshake() / tls.TLSClientHello(version="TLS_1_0",
+                                                                                                  gmt_unix_time=1234,
+                                                                                                  random_bytes="A" * 28,
+                                                                                                  session_id="",
+                                                                                                  compression_methods=[
+                                                                                                      0],
+                                                                                                  cipher_suites=(
+                                                                                                  tls.TLSCipherSuite.RSA_WITH_AES_128_CBC_SHA))
         tls_ctx.insert(client_hello)
-        server_hello = binascii.unhexlify("160301004a02000046030155662cd45fade845839a3c8dba0e46f1abcd2fd941f4e95e75ab6d61811abcf420960ccadc00abc7043cca458d9a1df1cb877a5005b53f754ac80d392990fae3c7002f00160301047c0b0004780004750004723082046e30820356a003020102020900d1e1f53a9203251a300d06092a864886f70d0101050500308180310b3009060355040613025553311330110603550408130a536f6d652d53746174653112301006035504071309536f6d652d6369747931153013060355040a130c536f6d652d636f6d70616e793110300e060355040b1307536f6d652d4f55311f301d06035504031316736f6d652d7365727665722e736f6d652e7768657265301e170d3135303532323139313631325a170d3235303531393139313631325a308180310b3009060355040613025553311330110603550408130a536f6d652d53746174653112301006035504071309536f6d652d6369747931153013060355040a130c536f6d652d636f6d70616e793110300e060355040b1307536f6d652d4f55311f301d06035504031316736f6d652d7365727665722e736f6d652e776865726530820122300d06092a864886f70d01010105000382010f003082010a0282010100cd7b7165ee7528f107cf666edc673eedc863544ebe8cc3741346015eea182a73a9e18e26f6f1553d83843d2bdacdd4501faec7b4f5446b8790053f152e23f70d121ca7f63a22a657536ee4b50b8777568ef469905ce05211178dd9ebe223b21246cce4baf351d0b81b464830e15fb7178cf5f39e7673de7779e5dbbd7a3d2ea98589b0d6003635447693ed2ec632c3dbb632ac254e3b8cd78e1ea160982627e2cd3a369c4bb43c486141b97fbbd9d3cb014b92e0ec6ecf46ded64749bbecfb6f98d0d2f459d5cf0054a6522280af961dfcbe1650937180f43decf2f8725b94eeec10248cdc70acad63bcc3cd5370d0dc0f3cba8d369909c6b917f243e5e5bc270203010001a381e83081e5301d0603551d0e041604143cc2f7fc85dbbe4b0566b35bde744484438ae83e3081b50603551d230481ad3081aa80143cc2f7fc85dbbe4b0566b35bde744484438ae83ea18186a48183308180310b3009060355040613025553311330110603550408130a536f6d652d53746174653112301006035504071309536f6d652d6369747931153013060355040a130c536f6d652d636f6d70616e793110300e060355040b1307536f6d652d4f55311f301d06035504031316736f6d652d7365727665722e736f6d652e7768657265820900d1e1f53a9203251a300c0603551d13040530030101ff300d06092a864886f70d0101050500038201010001738e2985692d8239fb1795e6ea0718755cf106cd739f7113afd3a074add07f981b06f34b9df3e1658c153355c5061b369d60d341eb4ccefdd98d6d6790be499cde8bd5705d1a8a89bb141599f3319914f8539e294848c106386218d8679da46ba90a2ce7587265cb55d6a629569b65581ee2e88ded264b81dff1c11e2c55728efe170dfe4f76706fbbda137b02e0fa987355b0cfdb3f8637e35473e4a6eccdcbc27d55d1f956a5f2c454e937df71d42e21d45d227477e26053b8be003fa527746b163b3d4b9a585d2860e5080ed9737d4c5fa5a32eee45a4e56d8a03542349619084580cc9c6c25b1ac7f3854b501423eafdd32896af92ce8ca6923947d77c16030100040e000000")
+        server_hello = binascii.unhexlify(
+            "160301004a02000046030155662cd45fade845839a3c8dba0e46f1abcd2fd941f4e95e75ab6d61811abcf420960ccadc00abc7043cca458d9a1df1cb877a5005b53f754ac80d392990fae3c7002f00160301047c0b0004780004750004723082046e30820356a003020102020900d1e1f53a9203251a300d06092a864886f70d0101050500308180310b3009060355040613025553311330110603550408130a536f6d652d53746174653112301006035504071309536f6d652d6369747931153013060355040a130c536f6d652d636f6d70616e793110300e060355040b1307536f6d652d4f55311f301d06035504031316736f6d652d7365727665722e736f6d652e7768657265301e170d3135303532323139313631325a170d3235303531393139313631325a308180310b3009060355040613025553311330110603550408130a536f6d652d53746174653112301006035504071309536f6d652d6369747931153013060355040a130c536f6d652d636f6d70616e793110300e060355040b1307536f6d652d4f55311f301d06035504031316736f6d652d7365727665722e736f6d652e776865726530820122300d06092a864886f70d01010105000382010f003082010a0282010100cd7b7165ee7528f107cf666edc673eedc863544ebe8cc3741346015eea182a73a9e18e26f6f1553d83843d2bdacdd4501faec7b4f5446b8790053f152e23f70d121ca7f63a22a657536ee4b50b8777568ef469905ce05211178dd9ebe223b21246cce4baf351d0b81b464830e15fb7178cf5f39e7673de7779e5dbbd7a3d2ea98589b0d6003635447693ed2ec632c3dbb632ac254e3b8cd78e1ea160982627e2cd3a369c4bb43c486141b97fbbd9d3cb014b92e0ec6ecf46ded64749bbecfb6f98d0d2f459d5cf0054a6522280af961dfcbe1650937180f43decf2f8725b94eeec10248cdc70acad63bcc3cd5370d0dc0f3cba8d369909c6b917f243e5e5bc270203010001a381e83081e5301d0603551d0e041604143cc2f7fc85dbbe4b0566b35bde744484438ae83e3081b50603551d230481ad3081aa80143cc2f7fc85dbbe4b0566b35bde744484438ae83ea18186a48183308180310b3009060355040613025553311330110603550408130a536f6d652d53746174653112301006035504071309536f6d652d6369747931153013060355040a130c536f6d652d636f6d70616e793110300e060355040b1307536f6d652d4f55311f301d06035504031316736f6d652d7365727665722e736f6d652e7768657265820900d1e1f53a9203251a300c0603551d13040530030101ff300d06092a864886f70d0101050500038201010001738e2985692d8239fb1795e6ea0718755cf106cd739f7113afd3a074add07f981b06f34b9df3e1658c153355c5061b369d60d341eb4ccefdd98d6d6790be499cde8bd5705d1a8a89bb141599f3319914f8539e294848c106386218d8679da46ba90a2ce7587265cb55d6a629569b65581ee2e88ded264b81dff1c11e2c55728efe170dfe4f76706fbbda137b02e0fa987355b0cfdb3f8637e35473e4a6eccdcbc27d55d1f956a5f2c454e937df71d42e21d45d227477e26053b8be003fa527746b163b3d4b9a585d2860e5080ed9737d4c5fa5a32eee45a4e56d8a03542349619084580cc9c6c25b1ac7f3854b501423eafdd32896af92ce8ca6923947d77c16030100040e000000")
         tls_ctx.insert(tls.TLS(server_hello))
         return tls_ctx
 
@@ -120,7 +134,8 @@ class TestTLSDissector(unittest.TestCase):
         self.assertEqual(pkt[0][tls.TLSRecord].length, 0x4a)
         self.assertEqual(pkt[0][tls.TLSHandshake].length, 0x46)
         self.assertEqual(pkt[0].gmt_unix_time, 1431391496)
-        self.assertEqual(pkt[0].session_id, binascii.unhexlify("2de1c20c707ba9b083282d2eba3d95bdfb5847eb9241f252173a04c9f990d508"))
+        self.assertEqual(pkt[0].session_id,
+                         binascii.unhexlify("2de1c20c707ba9b083282d2eba3d95bdfb5847eb9241f252173a04c9f990d508"))
         self.assertEqual(pkt[0].cipher_suite, tls.TLSCipherSuite.RSA_WITH_AES_128_CBC_SHA)
         self.assertEqual(pkt[0].compression_method, tls.TLSCompressionMethod.NULL)
         self.assertEqual(pkt[1].length, 0x408)
@@ -141,29 +156,37 @@ class TestTLSDissector(unittest.TestCase):
 
     def test_encrypted_layer_is_decrypted_if_required(self):
         tls_ctx = self._static_tls_handshake()
-        client_kex = tls.TLS.from_records([tls.TLSRecord()/tls.TLSHandshake()/tls.TLSClientKeyExchange()/tls_ctx.get_encrypted_pms(), tls.TLSRecord()/tls.TLSChangeCipherSpec()], tls_ctx)
+        client_kex = tls.TLS.from_records(
+            [tls.TLSRecord() / tls.TLSHandshake() / tls.TLSClientKeyExchange() / tls_ctx.get_encrypted_pms(),
+             tls.TLSRecord() / tls.TLSChangeCipherSpec()], tls_ctx)
         tls_ctx.insert(client_kex)
         tls_ctx.insert(tls.to_raw(tls.TLSFinished(), tls_ctx))
-        server_finished = binascii.unhexlify("14030100010116030100305b0241932c63c0cf1e4955e0cc65f751a3921fe8227c2bae045c66be327f7e68a39dc163b382c90d2caaf197ba0563a7")
+        server_finished = binascii.unhexlify(
+            "14030100010116030100305b0241932c63c0cf1e4955e0cc65f751a3921fe8227c2bae045c66be327f7e68a39dc163b382c90d2caaf197ba0563a7")
         server_finished_records = tls.TLS(server_finished, ctx=tls_ctx)
         tls_ctx.insert(server_finished_records)
         app_request = tls.to_raw(tls.TLSPlaintext(data="GET / HTTP/1.1\r\nHOST: localhost\r\n\r\n"), tls_ctx)
         tls_ctx.insert(app_request)
-        app_response = binascii.unhexlify("1703010020d691f8104d8fd877e7a7a7f3729936a92272c6fa93999f37a3a4b2355454a26617030107e04c7017bec4bb802bf713f815f692a50d1d911d8d78d8edc14b0e2dfde876b3da4ce748a0c6c1917490f73ba5d04fe61d250f5478416987904aa45461bc64848c3bdc573e6c99338634d9f374cba9b847b06e1f8c56039bda3b1fd5bf0007372472fa45333ccd907cec08d2e1d1beb6e1bbf7f155e09e71e480a32104873c60162d873fb0310d91261b120f51f5a7b75084d6c4bb6ba11ba59334343c96ad849e39ff09e356dcc34ef7b9857112b6a3530b85c17ac2093439e980cc1d3a78d5708ed0aea96e74fdeed11e1a2dd5dbce67f85554706a32b5b98a3a7f0752dcfe30dd1726f28d37d7eea7282efc3db3273e93cb30cec75bd200128372488b74213360ec885e720e8876cdd4a6ff0e4cd34e8726b3ce6e04e1462981f2d5acf00a4b9a478f1a6d39b3c66884364ee7b2c5294380ca140aa41d99af4b809abba5a613e690782b3ea1b09fe0daaadc32a2ca2023e19d07fa1f68d2e1268a4be72f1695676285567111cbfd89360a92227f1b7f3c2cbc92f329f02aee9b45868a11517419e7d70da2ca4709d174b5014e7d823e24d3e29ee8c62dbe7c2f1a631a5aa2571e5c5f23f2c7d78997c41eeabc91f413c90806736438c8d34f8114dfe595a0e22febab37fe04ad2966416ad0c307426dd9d3627b0642be021c5703ec40279115d11415e59dd86102ca018e8a4aed7c1988c8e53a36699fa8e55f903489bbcc9d281bd3822a927ac1536695c9419d87c30653c60b7f4b65647e4b1900b6b3963b5fc981bea5d131f1f92d81570f3dfd52287d6e7171107f2bda5f219eb2cb43d965b46ed425624b527d9c2a8ec0391144c7e9a67fead45d3cc7f0fbaeae21dd0297ecd00eea103675cf843ee7c545c611d41776adc90ddf6a4d4ff0c8fc8899b3eb76c79dbcac0d9f9b6c0e8a334a8bddff6f4f90b5b4004619bc50b65b309048c9b68d610033f2eb73dd2061e418826892494eff8df1adf5dc1b6968f620645c765507b49d48d734dd618c1dac32f28ab99f6dab2e401a8bbf8c19abf1181f8c1b98c7c06179fa096cbba3610710539b50c8f6c39fa92fe50635497dea7a4359a8dc1987ec329b3e06076ee2fa3e55fcc41f01c4c953587f60a14645850bf77675a78c6ac2cdb8a0bcf2eaf7a8f0ec154a6dc75f5c53c8ce8c733ad236b4d635fa49b6210b24a9d18326dcdac12bfff5551636306bdbbbe4190530e5a0704e9fb8f30ef7b1730686eb395c3d11c966caaeb14ee4138e8bcfe8f73119a0fab734eed3443944c6d8800124b6eeed36d530dcafa71d91657d97069b1604e7922094604aacecbf42cd487b15e2de25819fd4179ca615404307127640aa80eb8283e5462fe1abd5f9ebab03f6e95ba2bf2e8ba3e96170aed26565cde86777367e4b2193dfaceb350e1371394109e1f408c994f3c7dcc5eae506263834618a727c919f6e76898214c931f8d0d1b0200fb14a7d46e78d8634cbd918cc560e58cf2516498ecc55af46471ae01ba385727e262afe16510d54516d0c011ce678271f14a007d4c7f314cd5ae51ada413e315f85e3990b1686a8c3f9c06fe0d63e6c3438aa5b31ab526989d1f3577139eed35afdafdeb968fd88f15a670523db921a82428fac13a3cf67584e3bca1d3e7ac52ea6cf8a49992fceab78b837ed1d26cf3ce3aab33c85ac392e0e4baff9b63777f9339bfb8821759c8b4632e4ff41569fd5dda7cdadb44f1efc1dd5e19f76bff4bc9ea3b65dd0ba35cad76de5f075cb2a969a79b24c73ce8c40a2c72eb39c321404f784bd30c09073be67ed7fddcb5e1cecf78258d1b7d75dbc575c693ee045a44e09b020ca11fd62b72c5d5d5a0aa81936db25c400615c6a802bb3d218ec4cf135f27c288ba34db438902073b55e1dcd3afcef4d608d0ba63c1aecec0ea851de52931a6ccb3054a1f37a6cc2d62342226ea5249583aadd87f3bf308f5355d4d349772b14a6dba9076fa8a32cdc72cc2ee8c59bbdf2980192e8de69694d49cb81eb3e32770c477035130593c29288a10d67e0a261352c1d60c1565180c41c4ee7f3e07d4a5fb6f4d6c5ef087741ce6078ed8fecb1cf2894efb0b72d62119934831aab0d93ce7609b1d7b2e3d2b0fc0099e2ef70cd56a8cad09a4407ec34090d138b30adc2b872e286ddd22102ad8149fdb4b69266ba476aad1cc27fa4ca7170f2ac1e36c3800c6109e3e59007a681a2f22f836c1e75d86df4760959475a55e360503481adac9ad89b2f183f3366f8f71436a8717eb8b40ceb1b57e247b6aa79d88372fc45cfec9d26de12b4eb71bd2b322ccb49131b799ef5bfc240c2c6b0c4de812a0458865e85ea4b3738a164b845c82084dee165d0cfe88e96570f7f0eff3acbbcaeede932e2c3329349eae0e6f5b2eac5fe137f7a4ee5896b9dfa3f22e6b7f02868e3ca45be16f6df6f164e43ea4b57d1c2d9929336b0cc1c1267c0828d0e22b22481ab2a2a34824c2cd4408e663d16cf1111f13ddae650c5859da944f18892ff75997dd245c6e728670a5afd485002560b6e2e79cd43d08dbd31994ccbc6b0b222aaa415583cd2f3d12025db6c8bba2eeea56f9b806760c58eead3f71477987019c75d409e0ff1f99a0cb8910c818173823ab0f53f2f94bc8b054fc0bfd5f95e328c0d73fe4e2b9383be452c14d9d6882e371cd76e375d44aecb2e134cd86fdbaa367554f996b7918b4d32f83824a2486a2dafa83e5c0de439253083823311d07963ffb7b17edaa490acd07488868bf4a03eea544787d0eeae87c2079a2c4b0b860717637938660d6cbc4cf65f3e9f8b0eeb09ba8b2fab43fd074da31cc0c13692ea72f377aec89a77babb545b6da2f09a32")
+        app_response = binascii.unhexlify(
+            "1703010020d691f8104d8fd877e7a7a7f3729936a92272c6fa93999f37a3a4b2355454a26617030107e04c7017bec4bb802bf713f815f692a50d1d911d8d78d8edc14b0e2dfde876b3da4ce748a0c6c1917490f73ba5d04fe61d250f5478416987904aa45461bc64848c3bdc573e6c99338634d9f374cba9b847b06e1f8c56039bda3b1fd5bf0007372472fa45333ccd907cec08d2e1d1beb6e1bbf7f155e09e71e480a32104873c60162d873fb0310d91261b120f51f5a7b75084d6c4bb6ba11ba59334343c96ad849e39ff09e356dcc34ef7b9857112b6a3530b85c17ac2093439e980cc1d3a78d5708ed0aea96e74fdeed11e1a2dd5dbce67f85554706a32b5b98a3a7f0752dcfe30dd1726f28d37d7eea7282efc3db3273e93cb30cec75bd200128372488b74213360ec885e720e8876cdd4a6ff0e4cd34e8726b3ce6e04e1462981f2d5acf00a4b9a478f1a6d39b3c66884364ee7b2c5294380ca140aa41d99af4b809abba5a613e690782b3ea1b09fe0daaadc32a2ca2023e19d07fa1f68d2e1268a4be72f1695676285567111cbfd89360a92227f1b7f3c2cbc92f329f02aee9b45868a11517419e7d70da2ca4709d174b5014e7d823e24d3e29ee8c62dbe7c2f1a631a5aa2571e5c5f23f2c7d78997c41eeabc91f413c90806736438c8d34f8114dfe595a0e22febab37fe04ad2966416ad0c307426dd9d3627b0642be021c5703ec40279115d11415e59dd86102ca018e8a4aed7c1988c8e53a36699fa8e55f903489bbcc9d281bd3822a927ac1536695c9419d87c30653c60b7f4b65647e4b1900b6b3963b5fc981bea5d131f1f92d81570f3dfd52287d6e7171107f2bda5f219eb2cb43d965b46ed425624b527d9c2a8ec0391144c7e9a67fead45d3cc7f0fbaeae21dd0297ecd00eea103675cf843ee7c545c611d41776adc90ddf6a4d4ff0c8fc8899b3eb76c79dbcac0d9f9b6c0e8a334a8bddff6f4f90b5b4004619bc50b65b309048c9b68d610033f2eb73dd2061e418826892494eff8df1adf5dc1b6968f620645c765507b49d48d734dd618c1dac32f28ab99f6dab2e401a8bbf8c19abf1181f8c1b98c7c06179fa096cbba3610710539b50c8f6c39fa92fe50635497dea7a4359a8dc1987ec329b3e06076ee2fa3e55fcc41f01c4c953587f60a14645850bf77675a78c6ac2cdb8a0bcf2eaf7a8f0ec154a6dc75f5c53c8ce8c733ad236b4d635fa49b6210b24a9d18326dcdac12bfff5551636306bdbbbe4190530e5a0704e9fb8f30ef7b1730686eb395c3d11c966caaeb14ee4138e8bcfe8f73119a0fab734eed3443944c6d8800124b6eeed36d530dcafa71d91657d97069b1604e7922094604aacecbf42cd487b15e2de25819fd4179ca615404307127640aa80eb8283e5462fe1abd5f9ebab03f6e95ba2bf2e8ba3e96170aed26565cde86777367e4b2193dfaceb350e1371394109e1f408c994f3c7dcc5eae506263834618a727c919f6e76898214c931f8d0d1b0200fb14a7d46e78d8634cbd918cc560e58cf2516498ecc55af46471ae01ba385727e262afe16510d54516d0c011ce678271f14a007d4c7f314cd5ae51ada413e315f85e3990b1686a8c3f9c06fe0d63e6c3438aa5b31ab526989d1f3577139eed35afdafdeb968fd88f15a670523db921a82428fac13a3cf67584e3bca1d3e7ac52ea6cf8a49992fceab78b837ed1d26cf3ce3aab33c85ac392e0e4baff9b63777f9339bfb8821759c8b4632e4ff41569fd5dda7cdadb44f1efc1dd5e19f76bff4bc9ea3b65dd0ba35cad76de5f075cb2a969a79b24c73ce8c40a2c72eb39c321404f784bd30c09073be67ed7fddcb5e1cecf78258d1b7d75dbc575c693ee045a44e09b020ca11fd62b72c5d5d5a0aa81936db25c400615c6a802bb3d218ec4cf135f27c288ba34db438902073b55e1dcd3afcef4d608d0ba63c1aecec0ea851de52931a6ccb3054a1f37a6cc2d62342226ea5249583aadd87f3bf308f5355d4d349772b14a6dba9076fa8a32cdc72cc2ee8c59bbdf2980192e8de69694d49cb81eb3e32770c477035130593c29288a10d67e0a261352c1d60c1565180c41c4ee7f3e07d4a5fb6f4d6c5ef087741ce6078ed8fecb1cf2894efb0b72d62119934831aab0d93ce7609b1d7b2e3d2b0fc0099e2ef70cd56a8cad09a4407ec34090d138b30adc2b872e286ddd22102ad8149fdb4b69266ba476aad1cc27fa4ca7170f2ac1e36c3800c6109e3e59007a681a2f22f836c1e75d86df4760959475a55e360503481adac9ad89b2f183f3366f8f71436a8717eb8b40ceb1b57e247b6aa79d88372fc45cfec9d26de12b4eb71bd2b322ccb49131b799ef5bfc240c2c6b0c4de812a0458865e85ea4b3738a164b845c82084dee165d0cfe88e96570f7f0eff3acbbcaeede932e2c3329349eae0e6f5b2eac5fe137f7a4ee5896b9dfa3f22e6b7f02868e3ca45be16f6df6f164e43ea4b57d1c2d9929336b0cc1c1267c0828d0e22b22481ab2a2a34824c2cd4408e663d16cf1111f13ddae650c5859da944f18892ff75997dd245c6e728670a5afd485002560b6e2e79cd43d08dbd31994ccbc6b0b222aaa415583cd2f3d12025db6c8bba2eeea56f9b806760c58eead3f71477987019c75d409e0ff1f99a0cb8910c818173823ab0f53f2f94bc8b054fc0bfd5f95e328c0d73fe4e2b9383be452c14d9d6882e371cd76e375d44aecb2e134cd86fdbaa367554f996b7918b4d32f83824a2486a2dafa83e5c0de439253083823311d07963ffb7b17edaa490acd07488868bf4a03eea544787d0eeae87c2079a2c4b0b860717637938660d6cbc4cf65f3e9f8b0eeb09ba8b2fab43fd074da31cc0c13692ea72f377aec89a77babb545b6da2f09a32")
         app_response_records = tls.TLS(app_response, ctx=tls_ctx)
         tls_ctx.insert(app_response_records)
         # Test decryption against given states
         self.assertTrue(server_finished_records.haslayer(tls.TLSPlaintext))
         self.assertEqual(server_finished_records[tls.TLSPlaintext].padding_len, ord("\x0b"))
-        self.assertEqual(server_finished_records[tls.TLSPlaintext].padding, "\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b")
-        self.assertEqual(server_finished_records[tls.TLSPlaintext].mac, "\xac'\x9a\x94\xf6t'\x18E\x03nD\x0b\xf4\xf7\xf5T\xce\x05q")
-        self.assertEqual(server_finished_records[tls.TLSPlaintext].data, "\x14\x00\x00\x0c3\x13V\xac\x90.6\x89~7\x13\xbd")
+        self.assertEqual(server_finished_records[tls.TLSPlaintext].padding,
+                         "\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b")
+        self.assertEqual(server_finished_records[tls.TLSPlaintext].mac,
+                         "\xac'\x9a\x94\xf6t'\x18E\x03nD\x0b\xf4\xf7\xf5T\xce\x05q")
+        self.assertEqual(server_finished_records[tls.TLSPlaintext].data,
+                         "\x14\x00\x00\x0c3\x13V\xac\x90.6\x89~7\x13\xbd")
         self.assertTrue(app_response_records.haslayer(tls.TLSPlaintext))
         self.assertTrue(app_response_records[3][tls.TLSPlaintext].data.startswith("HTTP"))
 
     def test_cleartext_alert_is_not_decrypted_with_block_cipher(self):
         tls_ctx = self._static_tls_handshake()
-        alert = tls.TLSRecord()/tls.TLSAlert(level=tls.TLSAlertLevel.FATAL, description=tls.TLSAlertDescription.HANDSHAKE_FAILURE)
+        alert = tls.TLSRecord() / tls.TLSAlert(level=tls.TLSAlertLevel.FATAL,
+                                               description=tls.TLSAlertDescription.HANDSHAKE_FAILURE)
         record = tls.TLS(str(alert), ctx=tls_ctx)
         self.assertTrue(record.haslayer(tls.TLSAlert))
         self.assertEqual(record[tls.TLSAlert].level, tls.TLSAlertLevel.FATAL)
@@ -171,31 +194,32 @@ class TestTLSDissector(unittest.TestCase):
 
     def test_cleartext_handshake_is_not_decrypted(self):
         tls_ctx = self._static_tls_handshake()
-        handshake = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSServerKeyExchange()/tls.TLSServerDHParams()
+        handshake = tls.TLSRecord() / tls.TLSHandshake() / tls.TLSServerKeyExchange() / tls.TLSServerDHParams()
         record = tls.TLS(str(handshake), ctx=tls_ctx)
         self.assertTrue(record.haslayer(tls.TLSServerKeyExchange))
 
     def test_encrypted_handshake_which_fails_decryption_throws_error(self):
         tls_ctx = self._static_tls_handshake()
-        client_kex = tls.TLS.from_records([tls.TLSRecord()/tls.TLSHandshake()/tls.TLSClientKeyExchange()/tls_ctx.get_encrypted_pms(), tls.TLSRecord()/tls.TLSChangeCipherSpec()], tls_ctx)
+        client_kex = tls.TLS.from_records(
+            [tls.TLSRecord() / tls.TLSHandshake() / tls.TLSClientKeyExchange() / tls_ctx.get_encrypted_pms(),
+             tls.TLSRecord() / tls.TLSChangeCipherSpec()], tls_ctx)
         tls_ctx.insert(client_kex)
         tls_ctx.insert(tls.to_raw(tls.TLSFinished(), tls_ctx))
-        handshake = tls.TLSRecord()/tls.TLSHandshake()/"C"*5
+        handshake = tls.TLSRecord() / tls.TLSHandshake() / "C" * 5
         with self.assertRaises(ValueError):
             tls.TLS(str(handshake), ctx=tls_ctx)
 
 
 class TestTLSDecryptablePacket(unittest.TestCase):
-
     def test_packet_does_not_contain_mac_or_padding_if_not_received_encrypted(self):
-        pkt = tls.TLSRecord()/tls.TLSChangeCipherSpec()
+        pkt = tls.TLSRecord() / tls.TLSChangeCipherSpec()
         records = tls.TLS(str(pkt))
         with self.assertRaises(AttributeError):
             records[tls.TLSChangeCipherSpec].mac
             records[tls.TLSChangeCipherSpec].padding
 
     def test_tls_1_1_packet_does_not_contain_mac_or_padding_if_not_received_encrypted(self):
-        pkt = tls.TLSRecord(version=tls.TLSVersion.TLS_1_1)/tls.TLSChangeCipherSpec()
+        pkt = tls.TLSRecord(version=tls.TLSVersion.TLS_1_1) / tls.TLSChangeCipherSpec()
         records = tls.TLS(str(pkt))
         with self.assertRaises(AttributeError):
             records[tls.TLSChangeCipherSpec].explicit_iv
@@ -203,87 +227,89 @@ class TestTLSDecryptablePacket(unittest.TestCase):
             records[tls.TLSChangeCipherSpec].padding
 
     def test_session_context_is_removed_from_scapy_on_init(self):
-        pkt = tls.TLSRecord()/tls.TLSAlert()
+        pkt = tls.TLSRecord() / tls.TLSAlert()
         records = tls.TLS(str(pkt), ctx=tlsc.TLSSessionCtx())
         with self.assertRaises(KeyError):
             records.fields["ctx"]
 
     def test_streaming_mac_and_padding_are_added_if_session_context_is_provided(self):
-        data = "%s%s" % ("A"*2, "B"*MD5.digest_size)
+        data = "%s%s" % ("A" * 2, "B" * MD5.digest_size)
         tls_ctx = tlsc.TLSSessionCtx()
         tls_ctx.sec_params = tlsc.TLSSecurityParameters(tlsc.TLSPRF(tls.TLSVersion.TLS_1_0),
-                                                        tls.TLSCipherSuite.RSA_EXPORT1024_WITH_RC4_56_MD5, "A"*48,
-                                                        "B"*32, "C"*32)
+                                                        tls.TLSCipherSuite.RSA_EXPORT1024_WITH_RC4_56_MD5, "A" * 48,
+                                                        "B" * 32, "C" * 32)
         records = tls.TLSAlert(data, ctx=tls_ctx)
-        self.assertEqual("B"*MD5.digest_size, records[tls.TLSAlert].mac)
+        self.assertEqual("B" * MD5.digest_size, records[tls.TLSAlert].mac)
         self.assertEqual("", records[tls.TLSAlert].padding)
 
     def test_cbc_mac_and_padding_are_added_if_session_context_is_provided(self):
-        data = "%s%s%s" % ("A"*2, "B"*SHA.digest_size, "\x03"*4)
+        data = "%s%s%s" % ("A" * 2, "B" * SHA.digest_size, "\x03" * 4)
         tls_ctx = tlsc.TLSSessionCtx()
         tls_ctx.sec_params = tlsc.TLSSecurityParameters(tlsc.TLSPRF(tls.TLSVersion.TLS_1_0),
-                                                        tls.TLSCipherSuite.RSA_WITH_DES_CBC_SHA, "A"*48, "B"*32, "C"*32)
+                                                        tls.TLSCipherSuite.RSA_WITH_DES_CBC_SHA, "A" * 48, "B" * 32,
+                                                        "C" * 32)
         records = tls.TLSAlert(data, ctx=tls_ctx)
         self.assertEqual(ord("\x03"), records[tls.TLSAlert].padding_len)
-        self.assertEqual("\x03"*3, records[tls.TLSAlert].padding)
-        self.assertEqual("B"*SHA.digest_size, records[tls.TLSAlert].mac)
+        self.assertEqual("\x03" * 3, records[tls.TLSAlert].padding)
+        self.assertEqual("B" * SHA.digest_size, records[tls.TLSAlert].mac)
 
     def test_explicit_iv_is_added_for_tls_1_1_if_session_context_is_provided(self):
-        data = "%s%s%s%s" % ("C"*AES.block_size, "A"*2, "B"*SHA.digest_size, "\x03"*4)
+        data = "%s%s%s%s" % ("C" * AES.block_size, "A" * 2, "B" * SHA.digest_size, "\x03" * 4)
         tls_ctx = tlsc.TLSSessionCtx()
         tls_ctx.params.negotiated.version = tls.TLSVersion.TLS_1_1
         tls_ctx.sec_params = tlsc.TLSSecurityParameters(tlsc.TLSPRF(tls.TLSVersion.TLS_1_0),
-                                                        tls.TLSCipherSuite.RSA_WITH_AES_256_CBC_SHA, "A"*48, "B"*32,
-                                                        "C"*32, True)
+                                                        tls.TLSCipherSuite.RSA_WITH_AES_256_CBC_SHA, "A" * 48, "B" * 32,
+                                                        "C" * 32, True)
         records = tls.TLSAlert(data, ctx=tls_ctx)
         self.assertEqual(ord("\x03"), records[tls.TLSAlert].padding_len)
-        self.assertEqual("\x03"*3, records[tls.TLSAlert].padding)
-        self.assertEqual("B"*SHA.digest_size, records[tls.TLSAlert].mac)
-        self.assertEqual("C"*AES.block_size, records[tls.TLSAlert].explicit_iv)
+        self.assertEqual("\x03" * 3, records[tls.TLSAlert].padding)
+        self.assertEqual("B" * SHA.digest_size, records[tls.TLSAlert].mac)
+        self.assertEqual("C" * AES.block_size, records[tls.TLSAlert].explicit_iv)
+
 
 class TestTLSClientHello(unittest.TestCase):
-    
     def setUp(self):
-        self.pkt = tls.TLSRecord()/ \
-              tls.TLSHandshake()/ \
-              tls.TLSClientHello(extensions=[ \
-                    tls.TLSExtension()/ \
-                            tls.TLSExtServerNameIndication(server_names=[tls.TLSServerName(data="www.github.com"),
-                                                                         tls.TLSServerName(data="github.com")]), \
-                    tls.TLSExtension()/ \
-                            tls.TLSExtALPN(protocol_name_list=[tls.TLSALPNProtocol(data="http/1.1"),
-                                                               tls.TLSALPNProtocol(data="http/1.0")]),
-                    tls.TLSExtension()/ \
-                            tls.TLSExtALPN(protocol_name_list=[tls.TLSALPNProtocol(data="http/2.0"),]),
-                    tls.TLSExtension()/ \
-                            tls.TLSExtMaxFragmentLength(fragment_length=0x03),
-                    tls.TLSExtension()/ \
-                            tls.TLSExtCertificateURL(certificate_urls=[tls.TLSURLAndOptionalHash(url="http://www.github.com/tintinweb")]),
-                    tls.TLSExtension()/ \
-                            tls.TLSExtECPointsFormat(ec_point_formats=[tls.TLSEcPointFormat.ANSIX962_COMPRESSED_CHAR2]),
-                    tls.TLSExtension()/ \
-                            tls.TLSExtEllipticCurves(elliptic_curves=[tls.TLSEllipticCurve.SECT571R1,]),
-                    tls.TLSExtension()/ \
-                            tls.TLSExtHeartbeat(mode=tls.TLSHeartbeatMode.PEER_NOT_ALLOWED_TO_SEND),
-                    tls.TLSExtension()/ \
-                            tls.TLSExtSessionTicketTLS(data="myticket"),
-                    tls.TLSExtension()/ \
-                            tls.TLSExtRenegotiationInfo(data="myreneginfo"),
-                                ],)
+        self.pkt = tls.TLSRecord() / \
+                   tls.TLSHandshake() / \
+                   tls.TLSClientHello(extensions=[ \
+                       tls.TLSExtension() / \
+                       tls.TLSExtServerNameIndication(server_names=[tls.TLSServerName(data="www.github.com"),
+                                                                    tls.TLSServerName(data="github.com")]), \
+                       tls.TLSExtension() / \
+                       tls.TLSExtALPN(protocol_name_list=[tls.TLSALPNProtocol(data="http/1.1"),
+                                                          tls.TLSALPNProtocol(data="http/1.0")]),
+                       tls.TLSExtension() / \
+                       tls.TLSExtALPN(protocol_name_list=[tls.TLSALPNProtocol(data="http/2.0"), ]),
+                       tls.TLSExtension() / \
+                       tls.TLSExtMaxFragmentLength(fragment_length=0x03),
+                       tls.TLSExtension() / \
+                       tls.TLSExtCertificateURL(
+                           certificate_urls=[tls.TLSURLAndOptionalHash(url="http://www.github.com/tintinweb")]),
+                       tls.TLSExtension() / \
+                       tls.TLSExtECPointsFormat(ec_point_formats=[tls.TLSEcPointFormat.ANSIX962_COMPRESSED_CHAR2]),
+                       tls.TLSExtension() / \
+                       tls.TLSExtEllipticCurves(elliptic_curves=[tls.TLSEllipticCurve.SECT571R1, ]),
+                       tls.TLSExtension() / \
+                       tls.TLSExtHeartbeat(mode=tls.TLSHeartbeatMode.PEER_NOT_ALLOWED_TO_SEND),
+                       tls.TLSExtension() / \
+                       tls.TLSExtSessionTicketTLS(data="myticket"),
+                       tls.TLSExtension() / \
+                       tls.TLSExtRenegotiationInfo(data="myreneginfo"),
+                       ], )
         unittest.TestCase.setUp(self)
-        
+
     def test_dissect_contains_client_hello(self):
         p = tls.SSL(str(self.pkt))
-        self.assertEqual(len(p.records),1)
+        self.assertEqual(len(p.records), 1)
         record = p.records[0]
         self.assertTrue(record.haslayer(tls.TLSRecord))
         self.assertTrue(record.haslayer(tls.TLSHandshake))
         self.assertTrue(record.haslayer(tls.TLSClientHello))
-        
+
     def test_dissect_stacked_contains_multiple_client_hello(self):
         records = 5
-        p = tls.SSL(str(self.pkt)*records)
-        self.assertEqual(len(p.records),records)
+        p = tls.SSL(str(self.pkt) * records)
+        self.assertEqual(len(p.records), records)
         for record in p.records:
             self.assertTrue(record.haslayer(tls.TLSRecord))
             self.assertTrue(record.haslayer(tls.TLSHandshake))
@@ -299,42 +325,45 @@ class TestTLSClientHello(unittest.TestCase):
         self.assertEqual(record[tls.TLSClientHello].random_bytes, self.pkt[tls.TLSClientHello].random_bytes)
         self.assertEqual(record[tls.TLSClientHello].session_id, self.pkt[tls.TLSClientHello].session_id)
         self.assertEqual(record[tls.TLSClientHello].cipher_suites, self.pkt[tls.TLSClientHello].cipher_suites)
-        self.assertEqual(record[tls.TLSClientHello].compression_methods, self.pkt[tls.TLSClientHello].compression_methods)
-    
+        self.assertEqual(record[tls.TLSClientHello].compression_methods,
+                         self.pkt[tls.TLSClientHello].compression_methods)
+
     def test_dissect_client_hello_extensions(self):
         p = tls.SSL(str(self.pkt))
         record = p.records[0]
         extensions = record[tls.TLSClientHello].extensions
-        self.assertEquals(extensions.pop()[tls.TLSExtRenegotiationInfo].data, "myreneginfo") 
-        self.assertEquals(extensions.pop()[tls.TLSExtSessionTicketTLS].data, "myticket") 
-        self.assertEquals(extensions.pop()[tls.TLSExtHeartbeat].mode, tls.TLSHeartbeatMode.PEER_NOT_ALLOWED_TO_SEND) 
+        self.assertEquals(extensions.pop()[tls.TLSExtRenegotiationInfo].data, "myreneginfo")
+        self.assertEquals(extensions.pop()[tls.TLSExtSessionTicketTLS].data, "myticket")
+        self.assertEquals(extensions.pop()[tls.TLSExtHeartbeat].mode, tls.TLSHeartbeatMode.PEER_NOT_ALLOWED_TO_SEND)
         self.assertEquals(extensions.pop()[tls.TLSExtEllipticCurves].elliptic_curves[0], tls.TLSEllipticCurve.SECT571R1)
-        self.assertEquals(extensions.pop()[tls.TLSExtECPointsFormat].ec_point_formats[0], tls.TLSEcPointFormat.ANSIX962_COMPRESSED_CHAR2) 
-        self.assertEquals(extensions.pop()[tls.TLSExtCertificateURL].certificate_urls[0].url,"http://www.github.com/tintinweb") 
-        self.assertEquals(extensions.pop()[tls.TLSExtMaxFragmentLength].fragment_length,0x03)  
-        self.assertEquals(extensions.pop()[tls.TLSExtALPN].protocol_name_list[0].data,"http/2.0")  
+        self.assertEquals(extensions.pop()[tls.TLSExtECPointsFormat].ec_point_formats[0],
+                          tls.TLSEcPointFormat.ANSIX962_COMPRESSED_CHAR2)
+        self.assertEquals(extensions.pop()[tls.TLSExtCertificateURL].certificate_urls[0].url,
+                          "http://www.github.com/tintinweb")
+        self.assertEquals(extensions.pop()[tls.TLSExtMaxFragmentLength].fragment_length, 0x03)
+        self.assertEquals(extensions.pop()[tls.TLSExtALPN].protocol_name_list[0].data, "http/2.0")
         ext = extensions.pop()
-        self.assertEquals(ext[tls.TLSExtALPN].protocol_name_list[1].data,"http/1.0") 
-        self.assertEquals(ext[tls.TLSExtALPN].protocol_name_list[0].data,"http/1.1")
+        self.assertEquals(ext[tls.TLSExtALPN].protocol_name_list[1].data, "http/1.0")
+        self.assertEquals(ext[tls.TLSExtALPN].protocol_name_list[0].data, "http/1.1")
         ext = extensions.pop()
-        self.assertEquals(ext[tls.TLSExtServerNameIndication].server_names[1].data,"github.com") 
-        self.assertEquals(ext[tls.TLSExtServerNameIndication].server_names[0].data,"www.github.com")
+        self.assertEquals(ext[tls.TLSExtServerNameIndication].server_names[1].data, "github.com")
+        self.assertEquals(ext[tls.TLSExtServerNameIndication].server_names[0].data, "www.github.com")
 
     def test_dissect_client_hello_conditional_extensions_length(self):
         hello = tls.SSL(str(self.pkt))[tls.TLSClientHello]
         self.assertTrue("extensions_length=" in repr(hello))
         self.assertEqual(hello.extensions_length, len(''.join(str(e) for e in hello.extensions)))
 
-class TestTLSPlaintext(unittest.TestCase):
 
+class TestTLSPlaintext(unittest.TestCase):
     def test_built_plaintext_has_no_mac_and_padding_when_unspecified(self):
         plaintext = tls.TLSPlaintext(data="AAAA")
         self.assertEqual(str(plaintext), "AAAA")
 
     def test_built_plaintext_includes_mac_and_padding_if_not_empty(self):
-        data = "A"*4
-        mac="B"*16
-        padding="C"*19
+        data = "A" * 4
+        mac = "B" * 16
+        padding = "C" * 19
         plaintext = tls.TLSPlaintext(data=data, mac=mac, padding=padding)
         self.assertEqual(len(data) + len(mac) + len(padding) + 1, len(str(plaintext)))
         self.assertEqual(plaintext.mac, mac)
@@ -342,20 +371,20 @@ class TestTLSPlaintext(unittest.TestCase):
         self.assertEqual(ord(str(plaintext)[-1]), len(padding))
         self.assertEqual("%s%s%s%s" % (data, mac, padding, chr(len(padding))), str(plaintext))
 
+
 class TestPCAP(unittest.TestCase):
-    
     def setUp(self):
-        self.records =[]
+        self.records = []
         self.pkts = (p for p in rdpcap(env_local_file('RSA_WITH_AES_128_CBC_SHA.pcap')) if p.haslayer(tls.SSL))
         for p in (pkt for pkt in self.pkts):
             self.records += p.records
         unittest.TestCase.setUp(self)
-    
+
     def test_pcap_hello_conditional_extensions_length(self):
         for r in (rec for rec in self.records if rec.haslayer(tls.TLSServerHello) or rec.haslayer(tls.TLSClientHello)):
             self.assertTrue("extensions_length=" in repr(r))
             self.assertEqual(r.extensions_length, len(''.join(str(e) for e in r.extensions)))
-      
+
     def test_pcap_record_order(self):
         pkts = self.records
         pkts.reverse()
@@ -403,7 +432,11 @@ class TestPCAP(unittest.TestCase):
         self.assertTrue(record.haslayer(tls.TLSRecord))
         self.assertTrue(record.haslayer(tls.TLSHandshake))
         self.assertTrue(record.haslayer(tls.TLSClientKeyExchange))
-        self.assertEqual(record[tls.TLSClientKeyExchange].data, '\x9es\xdf\xe0\xf2\xd0@2D\x9a4\x7fW\x86\x10\xea=\xc5\xe2\xf9\xa5iC\xc9\x0b\x00~\x911W\xfc\xc5e\x18\rD\xfdQ\xf8\xda\x8az\xab\x16\x03\xeb\xac#n\x8d\xdd\xbb\xf4u\xe7\xb7\xa3\xce\xdbgk}0*')
+        # TODO: Client and Server KEX cannot be dissected without a TLS context
+        # self.assertTrue(record.haslayer(tls.TLSClientRSAParams))
+        # self.assertEqual(record[tls.TLSClientRSAParams].data)
+        self.assertEqual(str(record[tls.TLSClientKeyExchange])[2:],
+                         '\x9es\xdf\xe0\xf2\xd0@2D\x9a4\x7fW\x86\x10\xea=\xc5\xe2\xf9\xa5iC\xc9\x0b\x00~\x911W\xfc\xc5e\x18\rD\xfdQ\xf8\xda\x8az\xab\x16\x03\xeb\xac#n\x8d\xdd\xbb\xf4u\xe7\xb7\xa3\xce\xdbgk}0*')
         # Change Cipher Spec
         record = pkts.pop()
         self.assertTrue(record.haslayer(tls.TLSRecord))
@@ -415,7 +448,8 @@ class TestPCAP(unittest.TestCase):
         self.assertEquals(record[tls.TLSRecord].content_type, tls.TLSContentType.HANDSHAKE)
         self.assertTrue(record.haslayer(tls.TLSCiphertext))
         self.assertEqual(record[tls.TLSRecord].length, 0x30)
-        self.assertEqual(record[tls.TLSCiphertext].data, "\x15\xcbz[-\xc0'\t(b\x95D\x9f\xa1\x1eNj\xfbI\x9dj$D\xc6\x8e&\xbc\xc1(\x8c'\xcc\xa2\xba\xec8cnd\xd8R\x94\x17\x96a\xfd\x9cT")
+        self.assertEqual(record[tls.TLSCiphertext].data,
+                         "\x15\xcbz[-\xc0'\t(b\x95D\x9f\xa1\x1eNj\xfbI\x9dj$D\xc6\x8e&\xbc\xc1(\x8c'\xcc\xa2\xba\xec8cnd\xd8R\x94\x17\x96a\xfd\x9cT")
         # Handshake - new session ticket
         record = pkts.pop()
         self.assertTrue(record.haslayer(tls.TLSRecord))
@@ -423,7 +457,8 @@ class TestPCAP(unittest.TestCase):
         self.assertTrue(record.haslayer(tls.TLSSessionTicket))
         self.assertEqual(record[tls.TLSSessionTicket].lifetime, 7200)
         self.assertEqual(record[tls.TLSSessionTicket].ticket_length, 0xa0)
-        self.assertEqual(record[tls.TLSSessionTicket].ticket, '\xd4\xee\xb0\x9b\xb5\xa2\xd3\x00W\x84Y\xec\r\xbf\x05\x0c\xd5\xb9\xe2\xf82\xb5\xec\xce\xe2\x9c%%\xd9>J\x94[\xca\x18+\x0f_\xf6s8b\xcd\xcc\xf129\xe4^0\xf3\x94\xf5\xc5\x94:\x8c\x8e\xe5\x12J\x1e\xd81\xb5\x17\t\xa6Li\xca\xae\xfb\x04\x17dT\x9e\xc2\xfa\xf3m\xe9\xa5\xed\xa6e\xfe/\xf3\xc6\xcex@\xf7e\xe0\x13\xd3w\xc7\xc5y\x16VL0\x94\xcf\xb0<\x00\x91\xbd\x86\x08\x9f/\x05g\x03o\xa7;\xb96\xf2\x80O`]L\xc4B]\x02D\xba1\x8f9\x8e\x0c\x1e\xa8&O>\x01\x96\xb3o\xc6%\xe40\x03\xd6:}')
+        self.assertEqual(record[tls.TLSSessionTicket].ticket,
+                         '\xd4\xee\xb0\x9b\xb5\xa2\xd3\x00W\x84Y\xec\r\xbf\x05\x0c\xd5\xb9\xe2\xf82\xb5\xec\xce\xe2\x9c%%\xd9>J\x94[\xca\x18+\x0f_\xf6s8b\xcd\xcc\xf129\xe4^0\xf3\x94\xf5\xc5\x94:\x8c\x8e\xe5\x12J\x1e\xd81\xb5\x17\t\xa6Li\xca\xae\xfb\x04\x17dT\x9e\xc2\xfa\xf3m\xe9\xa5\xed\xa6e\xfe/\xf3\xc6\xcex@\xf7e\xe0\x13\xd3w\xc7\xc5y\x16VL0\x94\xcf\xb0<\x00\x91\xbd\x86\x08\x9f/\x05g\x03o\xa7;\xb96\xf2\x80O`]L\xc4B]\x02D\xba1\x8f9\x8e\x0c\x1e\xa8&O>\x01\x96\xb3o\xc6%\xe40\x03\xd6:}')
         # Change Cipher Spec
         record = pkts.pop()
         self.assertTrue(record.haslayer(tls.TLSRecord))
@@ -434,7 +469,8 @@ class TestPCAP(unittest.TestCase):
         self.assertTrue(record.haslayer(tls.TLSRecord))
         self.assertEquals(record[tls.TLSRecord].content_type, tls.TLSContentType.HANDSHAKE)
         self.assertTrue(record.haslayer(tls.TLSCiphertext))
-        self.assertEqual(record[tls.TLSCiphertext].data, '%\xb8X\xc1\xa6?\xf8\xbd\xe6\xae\xbd\x98\xd4u\xa5E\x1b\xd8jpy\x86)NOd\xba\xe7\x1f\xcaK\x96\x9b\xf7\x0bP\xf5O\xfd\xda\xda\xcd\xcdK\x12.\xdf\xd5')
+        self.assertEqual(record[tls.TLSCiphertext].data,
+                         '%\xb8X\xc1\xa6?\xf8\xbd\xe6\xae\xbd\x98\xd4u\xa5E\x1b\xd8jpy\x86)NOd\xba\xe7\x1f\xcaK\x96\x9b\xf7\x0bP\xf5O\xfd\xda\xda\xcd\xcdK\x12.\xdf\xd5')
         # some more encrypted traffic
         for _ in xrange(6):
             # Application data - encrypted - 6 times
@@ -442,14 +478,13 @@ class TestPCAP(unittest.TestCase):
             self.assertTrue(record.haslayer(tls.TLSRecord))
             self.assertEquals(record[tls.TLSRecord].content_type, tls.TLSContentType.APPLICATION_DATA)
             self.assertTrue(record.haslayer(tls.TLSCiphertext))
-            self.assertEqual(record.length,len(record[tls.TLSCiphertext].data))
+            self.assertEqual(record.length, len(record[tls.TLSCiphertext].data))
         # check if there are any more pakets?
         with self.assertRaises(IndexError):
-            record = pkts.pop() 
+            record = pkts.pop()
 
 
 class TestToRaw(unittest.TestCase):
-
     def setUp(self):
         self.pem_priv_key = """-----BEGIN PRIVATE KEY-----
 MIIEwAIBADANBgkqhkiG9w0BAQEFAASCBKowggSmAgEAAoIBAQDDLrmt4lKRpm6P
@@ -494,12 +529,15 @@ xVgf/Neb/avXgIgi6drj8dp1fWA=
         self.cipher_suite = 0x2f
         # NULL
         self.comp_method = 0x0
-        self.client_hello = tls.TLSRecord(version=self.record_version)/tls.TLSHandshake()/tls.TLSClientHello(version=self.hello_version, compression_methods=[self.comp_method], cipher_suites=[self.cipher_suite])
+        self.client_hello = tls.TLSRecord(version=self.record_version) / tls.TLSHandshake() / tls.TLSClientHello(
+            version=self.hello_version, compression_methods=[self.comp_method], cipher_suites=[self.cipher_suite])
         self.tls_ctx.insert(self.client_hello)
-        self.server_hello = tls.TLSRecord(version=self.hello_version)/tls.TLSHandshake()/tls.TLSServerHello(version=self.hello_version, compression_method=self.comp_method, cipher_suite=self.cipher_suite)
+        self.server_hello = tls.TLSRecord(version=self.hello_version) / tls.TLSHandshake() / tls.TLSServerHello(
+            version=self.hello_version, compression_method=self.comp_method, cipher_suite=self.cipher_suite)
         self.tls_ctx.insert(self.server_hello)
         # Build method to generate EPMS automatically in TLSSessionCtx
-        self.client_kex = tls.TLSRecord(version=self.hello_version)/tls.TLSHandshake()/tls.TLSClientKeyExchange(data=self.tls_ctx.get_encrypted_pms())
+        self.client_kex = tls.TLSRecord(version=self.hello_version) / tls.TLSHandshake() / tls.TLSClientKeyExchange() / \
+                          tls.TLSClientRSAParams(data=self.tls_ctx.get_encrypted_pms())
         self.tls_ctx.insert(self.client_kex)
         unittest.TestCase.setUp(self)
 
@@ -515,7 +553,7 @@ xVgf/Neb/avXgIgi6drj8dp1fWA=
     def test_record_payload_is_identical_to_raw_payload(self):
         pkt = tls.TLSPlaintext(data=b"ABCD")
         raw = tls.to_raw(pkt, self.tls_ctx, include_record=False)
-        record = tls.TLSRecord()/raw
+        record = tls.TLSRecord() / raw
         self.assertEqual(len(record[tls.TLSRecord]) - 0x5, len(raw))
         self.assertEqual(str(record[tls.TLSRecord].payload), raw)
 
@@ -523,16 +561,19 @@ xVgf/Neb/avXgIgi6drj8dp1fWA=
         # Return the data twice, but do not compress
         def custom_compress(comp_method, pre_compress_data):
             return pre_compress_data * 2
+
         # Return cleartext, null mac, null padding
         def pre_encrypt(crypto_container):
             crypto_container.mac = b""
             crypto_container.padding = b""
             return crypto_container
+
         # Return cleartext
         encrypt = lambda x: str(x)
         data = b"ABCD"
         pkt = tls.TLSPlaintext(data=data)
-        raw = tls.to_raw(pkt, self.tls_ctx, include_record=False, compress_hook=custom_compress, pre_encrypt_hook=pre_encrypt, encrypt_hook=encrypt)
+        raw = tls.to_raw(pkt, self.tls_ctx, include_record=False, compress_hook=custom_compress,
+                         pre_encrypt_hook=pre_encrypt, encrypt_hook=encrypt)
         self.assertEqual(len(raw), len(data) * 2)
         self.assertEqual(raw, data * 2)
 
@@ -552,14 +593,16 @@ xVgf/Neb/avXgIgi6drj8dp1fWA=
             self.assertEqual(len(crypto_container.mac), SHA.digest_size)
             self.assertEqual(len(crypto_container.padding), 11)
             self.assertTrue(all(map(lambda x: True if x == chr(11) else False, crypto_container.padding)))
-            return "A"*48
-        client_finished = tls.TLSRecord(content_type=0x16)/tls.to_raw(tls.TLSFinished(), self.tls_ctx, include_record=False, encrypt_hook=encrypt)
+            return "A" * 48
+
+        client_finished = tls.TLSRecord(content_type=0x16) / tls.to_raw(tls.TLSFinished(), self.tls_ctx,
+                                                                        include_record=False, encrypt_hook=encrypt)
         pkt = tls.TLS(str(client_finished))
         # 4 bytes of TLSHandshake header, 12 bytes of verify_data, 20 bytes of HMAC SHA1, 11 bytes of padding, 1 padding length byte
         self.assertEqual(pkt[tls.TLSRecord].length, len(tls.TLSHandshake()) + 12 + SHA.digest_size + 11 + 1)
 
+
 class TestTLSCertificate(unittest.TestCase):
-    
     def setUp(self):
         '''
         //default openssl 1.0.1f server.pem
@@ -621,10 +664,11 @@ UM6j0ZuSMFOCr/lGPAoOQU0fskidGEHi1/kW+suSr28TqsyYZpwBDQ==
         """
         self.der_priv_key = rex_pem.findall(self.pem_priv_key)[0].decode("base64")
         unittest.TestCase.setUp(self)
-        
+
     def test_tls_certificate_x509(self):
-        pkt = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSCertificateList(certificates=[tls.TLSCertificate(data=x509.X509Cert(self.der_cert))])
-        
+        pkt = tls.TLSRecord() / tls.TLSHandshake() / tls.TLSCertificateList(
+            certificates=[tls.TLSCertificate(data=x509.X509Cert(self.der_cert))])
+
         self.assertEqual(str(pkt[tls.TLSCertificateList].certificates[0].data), self.der_cert)
         self.assertEqual(str(pkt[tls.TLSCertificate].data), self.der_cert)
         try:
@@ -641,26 +685,27 @@ UM6j0ZuSMFOCr/lGPAoOQU0fskidGEHi1/kW+suSr28TqsyYZpwBDQ==
             self.fail(ae)
         # compare pubkeys
         self.assertEqual(pkt[tls.TLSCertificate].data.pubkey, pkt_d[tls.TLSCertificate].data.pubkey)
-        
+
     def test_tls_certificate_multiple_x509(self):
         # issue #27
-        pkt = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSCertificateList(certificates=[tls.TLSCertificate(data=x509.X509Cert(self.der_cert)),
-                                                                                      tls.TLSCertificate(data=x509.X509Cert(self.der_cert)),
-                                                                                      tls.TLSCertificate(data=x509.X509Cert(self.der_cert))])
+        pkt = tls.TLSRecord() / tls.TLSHandshake() / tls.TLSCertificateList(
+            certificates=[tls.TLSCertificate(data=x509.X509Cert(self.der_cert)),
+                          tls.TLSCertificate(data=x509.X509Cert(self.der_cert)),
+                          tls.TLSCertificate(data=x509.X509Cert(self.der_cert))])
 
         self.assertEqual(len(pkt[tls.TLSCertificateList].certificates), 3)
-        
+
         for tlscert in pkt[tls.TLSCertificateList].certificates:
             self.assertEqual(str(tlscert.data), self.der_cert)
             try:
                 tlscert.data.pubkey
             except AttributeError, ae:
                 self.fail(ae)
-        
+
         # serialize and dissect the same packet
         pkt_d = tls.SSL(str(pkt))
         self.assertEqual(len(pkt_d[tls.TLSCertificateList].certificates), 3)
-        
+
         for tlscert in pkt_d[tls.TLSCertificateList].certificates:
             self.assertEqual(str(tlscert.data), self.der_cert)
             try:
@@ -669,15 +714,16 @@ UM6j0ZuSMFOCr/lGPAoOQU0fskidGEHi1/kW+suSr28TqsyYZpwBDQ==
                 self.fail(ae)
             # compare pubkeys
             self.assertEqual(pkt[tls.TLSCertificate].data.pubkey, tlscert.data.pubkey)
-            
+
     def test_tls_certificate_x509_pubkey(self):
-        pkt = tls.TLSRecord()/tls.TLSHandshake()/tls.TLSCertificateList(certificates=[tls.TLSCertificate(data=x509.X509Cert(self.der_cert))])
+        pkt = tls.TLSRecord() / tls.TLSHandshake() / tls.TLSCertificateList(
+            certificates=[tls.TLSCertificate(data=x509.X509Cert(self.der_cert))])
         # dissect and extract pubkey
-        pkt = tls.SSL(str(pkt)) 
-        
+        pkt = tls.SSL(str(pkt))
+
         pubkey_extract_from_der = tlsc.x509_extract_pubkey_from_der(self.der_cert)
         pubkey_extract_from_tls_certificate = tlsc.x509_extract_pubkey_from_der(pkt[tls.TLSCertificate].data)
-        
+
         self.assertEqual(pubkey_extract_from_der, pubkey_extract_from_tls_certificate)
 
         self.assertTrue(pubkey_extract_from_der.can_encrypt())
@@ -685,16 +731,15 @@ UM6j0ZuSMFOCr/lGPAoOQU0fskidGEHi1/kW+suSr28TqsyYZpwBDQ==
 
         self.assertTrue(pubkey_extract_from_tls_certificate.can_encrypt())
         self.assertTrue(pubkey_extract_from_tls_certificate.can_sign())
-        
-        plaintext = "-!-plaintext-!-"*11
-        ciphertext = ''.join(pubkey_extract_from_tls_certificate.encrypt(plaintext,None))
-        ciphertext_2 = ''.join(pubkey_extract_from_der.encrypt(plaintext,None))
+
+        plaintext = "-!-plaintext-!-" * 11
+        ciphertext = ''.join(pubkey_extract_from_tls_certificate.encrypt(plaintext, None))
+        ciphertext_2 = ''.join(pubkey_extract_from_der.encrypt(plaintext, None))
         self.assertTrue(len(ciphertext))
-        self.assertEqual(ciphertext,ciphertext_2)
+        self.assertEqual(ciphertext, ciphertext_2)
 
 
 class TestTLSTopLevelFunctions(unittest.TestCase):
-
     def test_tls_payload_fragmentation_raises_error_with_negative_size(self):
         with self.assertRaises(ValueError):
             tls.tls_fragment_payload("AAAA", size=-1)

--- a/tests/test_ssl_tls_crypto.py
+++ b/tests/test_ssl_tls_crypto.py
@@ -165,7 +165,7 @@ xVgf/Neb/avXgIgi6drj8dp1fWA=
         tls_ctx.insert(client_kex)
         self.assertEqual(binascii.hexlify(tls_ctx.get_verify_data()), verify_data)
 
-    def test_client_dh_parameters_generateion_matches_fixed_data(self):
+    def test_client_dh_parameters_generation_matches_fixed_data(self):
         tls_ctx = tlsc.TLSSessionCtx()
         tls_ctx.crypto.server.dh.p = "\xdaX<\x16\xd9\x85\"\x89\xd0\xe4\xafuoL\xca\x92\xddK\xe53\xb8\x04\xfb\x0f\xed\x94\xef\x9c\x8aD\x03\xedWFP\xd3i\x99\xdb)\xd7v\'k\xa2\xd3\xd4\x12\xe2\x18\xf4\xdd\x1e\x08L\xf6\xd8\x00>|Gt\xe83"
         tls_ctx.crypto.server.dh.g = "\x02"

--- a/tests/test_ssl_tls_crypto.py
+++ b/tests/test_ssl_tls_crypto.py
@@ -144,7 +144,7 @@ xVgf/Neb/avXgIgi6drj8dp1fWA=
         epms = tls_ctx.get_encrypted_pms()
         pkt = tls.TLSRecord() / tls.TLSHandshake() / tls.TLSServerHello()
         tls_ctx.insert(pkt)
-        pkt = tls.TLSRecord() / tls.TLSHandshake() / tls.TLSClientKeyExchange(data=epms)
+        pkt = tls.TLSRecord() / tls.TLSHandshake() / tls.TLSClientKeyExchange() / tls.TLSClientRSAParams(data=epms)
         tls_ctx.insert(pkt)
         self.assertEqual(tls_ctx.crypto.session.encrypted_premaster_secret, epms)
         self.assertEqual(tls_ctx.crypto.session.premaster_secret, self.priv_key.decrypt(epms, None))
@@ -161,7 +161,8 @@ xVgf/Neb/avXgIgi6drj8dp1fWA=
         server_hello = tls.TLSRecord() / tls.TLSHandshake() / tls.TLSServerHello(gmt_unix_time=1234,
                                                                                  random_bytes="A" * 28)
         tls_ctx.insert(server_hello)
-        client_kex = tls.TLSRecord() / tls.TLSHandshake() / tls.TLSClientKeyExchange(data=epms)
+        client_kex = tls.TLSRecord() / tls.TLSHandshake() / tls.TLSClientKeyExchange() /\
+                     tls.TLSClientRSAParams(data=epms)
         tls_ctx.insert(client_kex)
         self.assertEqual(binascii.hexlify(tls_ctx.get_verify_data()), verify_data)
 
@@ -351,8 +352,8 @@ xVgf/Neb/avXgIgi6drj8dp1fWA=
             version=version, compression_method=self.comp_method, cipher_suite=self.cipher_suite)
         self.tls_ctx.insert(self.server_hello)
         # Build method to generate EPMS automatically in TLSSessionCtx
-        self.client_kex = tls.TLSRecord(version=self.version) / tls.TLSHandshake() / tls.TLSClientKeyExchange(
-            data=self.tls_ctx.get_encrypted_pms())
+        self.client_kex = tls.TLSRecord(version=self.version) / tls.TLSHandshake() / tls.TLSClientKeyExchange() /\
+                          tls.TLSClientRSAParams(data=self.tls_ctx.get_encrypted_pms())
         self.tls_ctx.insert(self.client_kex)
 
     def test_crypto_container_increments_sequence_number(self):


### PR DESCRIPTION
This was way more complicated then I expected, but it works in all cases I've tested:
* Had to parse `TLSClientKeyExchange()`payload differently for ECDHE (another brilliant TLS spec idea)
* Used tinyec to perform the EC DH secret calculation
* Supports only uncompressed EC points

Still need to:
* ~~Fill in the `TLSSecurityParameters.crypto_params` dictionary so it has all EC ciphers (Only `ECDHE_RSA_WITH_AES_128_CBC_SHA256` is there for now)~~
* Do some refactoring
* Explicitly check for the point type before performing the calculation

I'd appreciate some testing and feedback on this one though. I think all works, but it's a pretty massive PR.