### PR TITLE
Fixes pip/setup.py installation not finding all scapy installation locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,11 @@ Installation
 
 1) install requirements from requirements.txt
 
-2) copy scapy_ssl_tls/* to *scapy_installation*/scapy/layers 
+2) locate *< scapy >* installation directory: `python -c "import scapy; print scapy.__file__"`
 
-3) modify *scapy_installation*/scapy/config.py to autoload SSL/TLS 
+3) copy scapy_ssl_tls/* to *< scapy >*/layers/ 
+
+4) modify *< scapy >*/config.py to autoload SSL/TLS 
 
 ```diff
 
@@ -56,7 +58,15 @@ Installation
 
 ##### verify installation:
 ```python
-#> scapy
+#> python
+	>>> from scapy_ssl_tls.ssl_tls import TLS
+	>>> TLS
+	<class 'scapy_ssl_tls.ssl_tls.SSL'>
+#> scapy  # via site-packages
+	>>> from scapy_ssl_tls.ssl_tls import TLS
+	>>> TLS
+	<class 'scapy_ssl_tls.ssl_tls.SSL'>
+#> scapy  # with layers autoloaded via config.py
 	>>> SSL
 	<class 'scapy.layers.ssl_tls.SSL'>
 	>>> TLS

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import platform
 import sys
 from setuptools import setup
 from setuptools.command.install import install as _install
-
+import site as _site
 
 def get_site_packages():
     """
@@ -25,7 +25,11 @@ def get_site_packages():
         site_path = os.path.join(os_location, site)
         if os.path.isdir(site_path):
             site_packages.append(site_path)
-    return site_packages
+    try:
+        site_packages += _site.getsitepackages()
+    except AttributeError:
+        print("WARNING: Error trying to call site.getsitepackages(). This is probably virtualenv issue#355")
+    return list(set(site_packages))
 
 
 def get_scapy_locations(sites):
@@ -48,6 +52,7 @@ def get_scapy_locations(sites):
                             for dir_ in dirs:
                                 if dir_ == "layers":
                                     scapy_locations.append(root)
+    print("INFO: Installing scapy-ssl_tls layers to: %s"%repr(scapy_locations))
     return scapy_locations
 
 


### PR DESCRIPTION
* Adds debug output to setup.py showing all install dirs
* Fixes a bug where setup.py won't find all scapy installations when scapy was installed to /usr/lib/python/.. and /usr/local/lib/python/... (kali1 with scapy updated from pip)
* probably fixes https://stackoverflow.com/questions/33998726/cannot-import-scapy-ssl-tls-library
* Updated Readme.md to address verification for the various installation procedures.