### PR TITLE
Server automata

### DIFF
--- a/examples/tls_client_automata.py
+++ b/examples/tls_client_automata.py
@@ -4,6 +4,8 @@
 
 import os
 import sys
+import logging
+logger = logging.getLogger(__name__)
 
 from scapy.all import conf, log_interactive
 
@@ -18,9 +20,9 @@ except ImportError:
     from scapy.layers.ssl_tls_automata import TLSClientAutomata
     from scapy.layers.ssl_tls import *
 
-
-
 if __name__=='__main__':
+    #conf.prog.dot = r'"path_to_graphviz/dot"'
+    logging.basicConfig(level=logging.DEBUG)
     log_interactive.setLevel(1)
 
     if len(sys.argv)>2:
@@ -30,7 +32,7 @@ if __name__=='__main__':
 
     TLSClientAutomata.graph()
 
-    auto_cli = TLSClientAutomata(debug=10,
+    auto_cli = TLSClientAutomata(debug=9,
                              target=target,
                              tls_version="TLS_1_1",
                              cipher_suites=[TLSCipherSuite.RSA_WITH_AES_128_CBC_SHA,
@@ -38,5 +40,20 @@ if __name__=='__main__':
                                             TLSCipherSuite.DHE_RSA_WITH_AES_128_CBC_SHA,
                                             TLSCipherSuite.DHE_DSS_WITH_AES_128_CBC_SHA],
                              request="GET / HTTP/1.1\r\nHOST: localhost\r\n\r\n")
+    
+    logger.debug("registered states: %s"%auto_cli.states)   # all registered states
+    logger.debug("registered actions: %s"%auto_cli.actions) # all registered actions
+    logger.debug("pkt-to-state-mapping: %s"%auto_cli.STATES)# mapped pkts to states
+    logger.debug("pkt-to-action-mapping: %s"%auto_cli.ACTIONS)# mapped pkts to actions
 
+    # uncomment next lines to hook into the 'send_server_hello' condition.
+    '''
+    def jump_to_random_state(*args, **kwargs):
+        import random
+        next_state = random.choice(auto_cli.states.keys())
+        raw_input(" **** -------------> override state, random pick: %s"%next_state)
+        raise getattr(auto_cli,next_state)()
+    
+    auto_cli.register_callback(auto_cli.ACTIONS[TLSFinished], jump_to_random_state)
+    '''
     print auto_cli.run()

--- a/examples/tls_server_automata.py
+++ b/examples/tls_server_automata.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+# Author : tintinweb@oststrom.com <github.com/tintinweb>
+
+import os
+import sys
+
+from scapy.all import conf, log_interactive
+
+try:
+    # This import works from the project directory
+    basedir = os.path.abspath(os.path.join(os.path.dirname(__file__),"../"))
+    sys.path.append(basedir)
+    from scapy_ssl_tls.ssl_tls_automata import TLSServerAutomata
+    from scapy_ssl_tls.ssl_tls import *
+except ImportError:
+    # If you installed this package via pip, you just need to execute this
+    from scapy.layers.ssl_tls_automata import TLSServerAutomata
+    from scapy.layers.ssl_tls import *
+
+
+if __name__=='__main__':
+    log_interactive.setLevel(1)
+ 
+    if len(sys.argv)>2:
+        target = (sys.argv[1],int(sys.argv[2]))
+    else:
+        target = ("127.0.0.1", 8443)
+ 
+    TLSServerAutomata.graph()
+    auto_srv = TLSServerAutomata(debug=9,
+                             target=target,
+                             tls_version="TLS_1_1",
+                             cipher_suite=TLSCipherSuite.RSA_WITH_AES_128_CBC_SHA,
+                             response="HTTP/1.1 200 OK\r\n\r\n")
+    print auto_srv.run()

--- a/examples/tls_server_automata.py
+++ b/examples/tls_server_automata.py
@@ -26,11 +26,16 @@ if __name__=='__main__':
         target = (sys.argv[1],int(sys.argv[2]))
     else:
         target = ("127.0.0.1", 8443)
+        
+    server_pem = sys.argv[3] if len(sys.argv)>3 else "../tests/files/openssl_1_0_1_f_server.pem"
  
     TLSServerAutomata.graph()
+    print "using certificate/keyfile: %s"%server_pem
+    with open(server_pem,'r') as f:
+        pemcert = f.read()
     auto_srv = TLSServerAutomata(debug=9,
-                             target=target,
-                             tls_version="TLS_1_1",
+                             bind=target,
+                             pemcert=pemcert,
                              cipher_suite=TLSCipherSuite.RSA_WITH_AES_128_CBC_SHA,
                              response="HTTP/1.1 200 OK\r\n\r\n")
     print auto_srv.run()

--- a/examples/tls_server_automata.py
+++ b/examples/tls_server_automata.py
@@ -38,4 +38,11 @@ if __name__=='__main__':
                              pemcert=pemcert,
                              cipher_suite=TLSCipherSuite.RSA_WITH_AES_128_CBC_SHA,
                              response="HTTP/1.1 200 OK\r\n\r\n")
+    
+    def jump_to_server_hello_done(*args, **kwargs):
+        raw_input(" **** -------------> override state, directly jump to SERVER_CERTIFICATES_SENT aka. SERVER_HELLO_DONE")
+        raise auto_srv.SERVER_CERTIFICATES_SENT()
+    
+    # uncomment next line to hook into the 'send_server_hello' condition.  
+    # auto_srv.register_callback('send_server_hello', jump_to_server_hello_done)
     print auto_srv.run()

--- a/examples/tls_server_automata.py
+++ b/examples/tls_server_automata.py
@@ -20,9 +20,8 @@ except ImportError:
     from scapy.layers.ssl_tls_automata import TLSServerAutomata
     from scapy.layers.ssl_tls import *
 
-
 if __name__=='__main__':
-    #conf.prog.dot = '"path_to_graphviz/dot"'
+    #conf.prog.dot = r'"path_to_graphviz/dot"'
     logging.basicConfig(level=logging.DEBUG)
     log_interactive.setLevel(1)
     
@@ -34,6 +33,7 @@ if __name__=='__main__':
     server_pem = sys.argv[3] if len(sys.argv)>3 else "../tests/files/openssl_1_0_1_f_server.pem"
  
     TLSServerAutomata.graph()
+
     logger.info("using certificate/keyfile: %s"%server_pem)
     with open(server_pem,'r') as f:
         pemcert = f.read()
@@ -43,14 +43,27 @@ if __name__=='__main__':
                              cipher_suite=TLSCipherSuite.RSA_WITH_AES_128_CBC_SHA,
                              response="HTTP/1.1 200 OK\r\n\r\n")
     
-    def jump_to_server_hello_done(*args, **kwargs):
-        raw_input(" **** -------------> override state, directly jump to SERVER_CERTIFICATES_SENT aka. SERVER_HELLO_DONE")
-        raise auto_srv.SERVER_CERTIFICATES_SENT()
-
     logger.debug("registered states: %s"%auto_srv.states)   # all registered states
     logger.debug("registered actions: %s"%auto_srv.actions) # all registered actions
     logger.debug("pkt-to-state-mapping: %s"%auto_srv.STATES)# mapped pkts to states
     logger.debug("pkt-to-action-mapping: %s"%auto_srv.ACTIONS)# mapped pkts to actions
-    # uncomment next line to hook into the 'send_server_hello' condition.  
-    # auto_srv.register_callback(auto_srv.ACTIONS[TLSServerHello], jump_to_server_hello_done)
+    
+    # uncomment next line to hook into the 'send_server_hello' condition.
+    '''
+    def jump_to_server_hello_done(*args, **kwargs):
+        raw_input(" **** -------------> override state, directly jump to SERVER_CERTIFICATES_SENT aka. SERVER_HELLO_DONE")
+        raise auto_srv.SERVER_CERTIFICATES_SENT()
+    
+    def jump_to_random_state(*args, **kwargs):
+        import random
+        next_state = random.choice(auto_srv.states.keys())
+        raw_input(" **** -------------> override state, random pick: %s"%next_state)
+        raise getattr(auto_srv,next_state)()
+    
+    def jump_to_bla(*args, **kwargs):
+        raise auto_srv.WAIT_FOR_CLIENT_CONNECTION()
+    
+    auto_srv.register_callback(auto_srv.ACTIONS[TLSFinished], jump_to_server_hello_done)
+    auto_srv.register_callback(auto_srv.ACTIONS[TLSFinished], jump_to_random_state)
+    '''
     print auto_srv.run()

--- a/scapy_ssl_tls/ssl_tls_automata.py
+++ b/scapy_ssl_tls/ssl_tls_automata.py
@@ -180,3 +180,186 @@ class TLSClientAutomata(Automaton):
     @ATMT.state(final=1)
     def END(self, p):
         return ''.join(pkt[TLSPlaintext].data for pkt in p.records)
+
+
+
+class TLSServerAutomata(Automaton):
+    """"A Simple TLS Server Automata
+    
+        TLSServerAutomata.graph()
+        auto_srv = TLSServerAutomata(debug=9,
+                                 target=("127.0.0.1",65009),
+                                 tls_version="TLS_1_1",
+                                 cipher_suite=TLSCipherSuite.RSA_WITH_AES_128_CBC_SHA,
+                                 response="HTTP/1.1 200 OK\r\n\r\n")
+        auto_srv.run()
+    """
+    def parse_args(self, 
+                   target, 
+                   tls_version='TLS_1_1', 
+                   response="HTTP/1.1 200 OK\r\n\r\n", 
+                   cipher_suite=TLSCipherSuite.RSA_WITH_AES_128_CBC_SHA,
+                   timeout=4.0, 
+                   **kwargs):
+        Automaton.parse_args(self, **kwargs)
+        self.target = target
+        self.tls_version = tls_version
+        self.response = response
+        self.cipher_suite = cipher_suite
+        self.timeout = timeout
+        self.tlssock = None
+        self.srv_sock = None
+        self.peer = None
+        self.debug(1,"parse_args - done")
+
+    # GENERIC BEGIN
+    @ATMT.state(initial=1)
+    def BEGIN(self):
+        self.debug(1,"BEGIN")
+    
+    @ATMT.condition(BEGIN)
+    def listen(self):
+        raise self.WAIT_FOR_CLIENT_CONNECTION()
+    
+    @ATMT.action(listen)
+    def do_bind(self):
+        self.debug(1,"dobind")
+        self.srv_sock = socket.socket(socket.AF_INET,socket.SOCK_STREAM)
+        self.srv_sock.bind(self.target)
+        self.srv_sock.listen(1)
+        
+        self.debug(1,"server bound to %s:%d"%self.target)
+        
+    @ATMT.state()
+    def WAIT_FOR_CLIENT_CONNECTION(self):
+        self.debug(1,"accept")
+        self.peer = self.srv_sock.accept()
+        self.tlssock = TLSSocket(self.peer[0], client=False)
+    
+    @ATMT.condition(WAIT_FOR_CLIENT_CONNECTION)
+    def recv_client_hello(self):
+        p = self.tlssock.recvall(timeout=self.timeout)
+        p.show()
+        if not p.haslayer(TLSClientHello):
+            raise self.ERROR(p)
+        raise self.CLIENT_HELLO_RECV()
+    
+    @ATMT.state()
+    def CLIENT_HELLO_RECV(self):
+        pass
+    
+    @ATMT.condition(CLIENT_HELLO_RECV)
+    def send_server_hello(self):
+        raise self.SERVER_HELLO_SENT()
+    
+    @ATMT.action(send_server_hello)
+    def do_send_server_hello(self):
+        rec_hs = TLSRecord(version=self.tls_version) / TLSHandshake()
+        server_hello = rec_hs/TLSServerHello(version=self.tls_version, 
+                                             compression_method=TLSCompressionMethod.NULL,
+                                             cipher_suite=self.cipher_suite)
+        server_hello.show()
+        self.tlssock.sendall(server_hello)
+        
+        #TODO: remove static server cert/key 
+        #pem = ssl_tls_crypto.pem_get_objects(open("../tests/files/openssl_1_0_1_f_server.pem",'r').read())
+        
+        #key = pem['RSA PRIVATE KEY']['full'].replace("\n","")
+        key = "MIIEpAIBAAKCAQEA84TzkjbcskbKZnrlKcXzSSgi07n+4N7kOM7uIhzpkTuU0HIvh4VZS2axxfV6hV3CD9MuKVg2zEhroqK1Js5n4ke230nSP/qiELfCl0R+hzRtbfKLtFUr1iHeU0uQ6v3q+Tg1K/Tmmg72uxKrhyHDL7z0BriPjhAHJ5XlQsvR1RCMkqzuD9wjSInJxpMMIgLndOclAKv4D1wQtYU7ZpTw+01XBlUhIiXb86qpYL9NqnnRq5JIuhmOEuxo2ca63+xaHNhD/udSyc8C0Md/yX6wlONTRFgLLv0pdLUGm1xEjfsydaQ6qGd7hzIKUI3hohNKJa/mHLElv7SZolPTogK/EQIDAQABAoIBAADq9FwNtuE5IRQnzGtO4q7Y5uCzZ8GDNYr9RKp+P2cbuWDbvVAecYq2NV9QoIiWJOAYZKklOvekIju3r0UZLA0PRiIrTg6NrESx3JrjWDK8QNlUO7CPTZ39/K+FrmMkV9lem9yxjJjyC34DAQB+YRTx+l14HppjdxNwHjAVQpIx/uO2F5xAMuk32+3K+pq9CZUtrofe1q4Agj9R5s8mSy9pbRo9kW9wl5xdEotz1LivFOEiqPUJTUq5J5PeMKao3vdK726XI4Z455NmW2/MA0YV0ug2FYinHcZdvKM6dimH8GLfa3X8xKRfzjGjTiMSwsdjgMa4awY3tEHH674jhAECgYEA/zqMrc0zsbNk83sjgaYIug5kzEpN4ic020rSZsmQxSCerJTgNhmgutKSCt0Re09Jt3LqG48msahX8ycqDsHNvlEGPQSbMu9IYeO3Wr3fAm75GEtFWePYBhM73I7gkRt4s8bUiUepMG/wY45c5tRF23xi8foReHFFe9MDzh8fJFECgYEA9EFX4qAik1pOJGNei9BMwmx0I0gfVEIgu0tzeVqT45vcxbxr7RkTEaDoAG6PlbWP6D9aWQNLp4gsgRM90ZXOJ4up5DsAWDluvaF4/omabMA+MJJ5kGZ0gCj5rbZbKqUws7x8bp+6iBfUPJUbcqNqFmi/08Yt7vrDnMnyMw2A/sECgYEAiiuRMxnuzVm34hQcsbhH6ymVqf7j0PW2qK0F4H1ocT9qhzWFd+RB3kHWrCjnqODQoI6GbGr/4JepHUpre1ex4UEN5oSS3G0ru0rC3U4C59dZ5KwDHFm7ffZ1pr52ljfQDUsrjjIMRtuiwNK2OoRaWSsqiaL+SDzSB+nBmpnAizECgYBdt/y6rerWUx4MhDwwtTnel7JwHyo2MDFS6/5gn8qC2Lj6/fMDRE22w+CA2esp7EJNQJGv+b27iFpbJEDh+/Lf5YzIT4MwVskQ5bYBJFcmRxUVmf4e09D7o705U/DjCgMH09iCsbLmqQ38ONIRSHZaJtMDtNTHD1yi+jF+OT43gQKBgQC/2OHZoko6iRlNOAQ/tMVFNq7fL81GivoQ9F1U0Qr+DH3ZfaH8eIkXxT0ToMPJUzWAn8pZv0snA0um6SIgvkCuxO84OkANCVbttzXImIsL7pFzfcwV/ERKUM6j0ZuSMFOCr/lGPAoOQU0fskidGEHi1/kW+suSr28TqsyYZpwBDQ==".decode("base64")
+        #cert = pem['CERTIFICATE']['full'].replace("\n","")
+        cert = "MIID5zCCAs+gAwIBAgIJALnu1NlVpZ6zMA0GCSqGSIb3DQEBBQUAMHAxCzAJBgNVBAYTAlVLMRYwFAYDVQQKDA1PcGVuU1NMIEdyb3VwMSIwIAYDVQQLDBlGT1IgVEVTVElORyBQVVJQT1NFUyBPTkxZMSUwIwYDVQQDDBxPcGVuU1NMIFRlc3QgSW50ZXJtZWRpYXRlIENBMB4XDTExMTIwODE0MDE0OFoXDTIxMTAxNjE0MDE0OFowZDELMAkGA1UEBhMCVUsxFjAUBgNVBAoMDU9wZW5TU0wgR3JvdXAxIjAgBgNVBAsMGUZPUiBURVNUSU5HIFBVUlBPU0VTIE9OTFkxGTAXBgNVBAMMEFRlc3QgU2VydmVyIENlcnQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDzhPOSNtyyRspmeuUpxfNJKCLTuf7g3uQ4zu4iHOmRO5TQci+HhVlLZrHF9XqFXcIP0y4pWDbMSGuiorUmzmfiR7bfSdI/+qIQt8KXRH6HNG1t8ou0VSvWId5TS5Dq/er5ODUr9OaaDva7EquHIcMvvPQGuI+OEAcnleVCy9HVEIySrO4P3CNIicnGkwwiAud05yUAq/gPXBC1hTtmlPD7TVcGVSEiJdvzqqlgv02qedGrkki6GY4S7GjZxrrf7Foc2EP+51LJzwLQx3/JfrCU41NEWAsu/Sl0tQabXESN+zJ1pDqoZ3uHMgpQjeGiE0olr+YcsSW/tJmiU9OiAr8RAgMBAAGjgY8wgYwwDAYDVR0TAQH/BAIwADAOBgNVHQ8BAf8EBAMCBeAwLAYJYIZIAYb4QgENBB8WHU9wZW5TU0wgR2VuZXJhdGVkIENlcnRpZmljYXRlMB0GA1UdDgQWBBSCvM8AABPR9zklmifnr9LvIBturDAfBgNVHSMEGDAWgBQ2w2yI55X+sL3szj49hqshgYfa2jANBgkqhkiG9w0BAQUFAAOCAQEAqb1NV0B0/pbpK9Z4/bNjzPQLTRLKWnSNm/Jh5v0GEUOE/Beg7GNjNrmeNmqxAlpqWz9qoeoFZax+QBpIZYjROU3TS3fpyLsrnlr0CDQ5R7kCCDGa8dkXxemmpZZLbUCpW2Uoy8sAA4JjN9OtsZY7dvUXFgJ7vVNTRnI01ghknbtD+2SxSQd3CWF6QhcRMAzZJ1z1cbbwGDDzfvGFPzJ+Sq+zEPdsxoVLLSetCiBc+40ZcDS5dV98h9XD7JMTQfxzA7mNGv73JoZJA6nFgj+ADSlJsY/tJBv+z1iQRueoh9Qeee+ZbRifPouCB8FDx+AltvHTANdAq0t/K3o+pplMVA==".decode("base64")
+
+        server_certificates = rec_hs / TLSCertificateList(certificates=[TLSCertificate(data=x509.X509Cert(cert))])
+        server_certificates.show()
+        self.tlssock.sendall(server_certificates)
+        (rec_hs / TLSServerHelloDone()).show2()
+        server_hello_done = TLSRecord(version=self.tls_version) / TLSHandshake(type=TLSHandshakeType.SERVER_HELLO_DONE)
+        self.tlssock.sendall(server_hello_done)
+    
+    @ATMT.state()
+    def SERVER_HELLO_SENT(self):
+        pass
+    
+    @ATMT.condition(SERVER_HELLO_SENT)
+    def recv_client_key_exchange(self):
+        p = self.tlssock.recvall()
+        p.show()
+        if not p.haslayer(TLSClientKeyExchange):
+            raise self.ERROR(p)
+        raise self.CLIENT_KEY_EXCHANGE_RECV()
+    
+    @ATMT.state()
+    def CLIENT_KEY_EXCHANGE_RECV(self):
+        raise self.CLIENT_CHANGE_CIPHERSPEC_RECV()
+    
+    @ATMT.state()
+    def CLIENT_CHANGE_CIPHERSPEC_RECV(self):
+        raise self.CLIENT_FINISH_RECV()
+    
+    @ATMT.state()
+    def CLIENT_FINISH_RECV(self):
+        pass
+  
+    @ATMT.condition(CLIENT_FINISH_RECV)
+    def send_server_ccs(self):
+        raise self.SERVER_CCS_SENT()
+
+    @ATMT.action(send_server_ccs)
+    def do_send_server_ccs(self):
+        tls_version = self.tlssock.tls_ctx.params.negotiated.version
+        client_ccs = TLSRecord(version=tls_version) / TLSChangeCipherSpec()
+        self.tlssock.sendall(client_ccs)
+
+    @ATMT.state()
+    def SERVER_CCS_SENT(self):
+        pass
+ 
+    @ATMT.condition(SERVER_CCS_SENT)
+    def send_server_finish(self):
+        raise self.SERVER_FINISH_SENT()
+    
+    @ATMT.action(send_server_finish)
+    def do_send_server_finish(self):
+        #TODO: fix server finish calculation
+        finished = to_raw(TLSFinished(), self.tlssock.tls_ctx)
+        self.tlssock.sendall(finished)
+    
+    @ATMT.state()
+    def SERVER_FINISH_SENT(self):
+        pass
+    
+    @ATMT.condition(SERVER_FINISH_SENT)
+    def recv_client_appdata(self):
+        p = self.tlssock.recvall()
+        p.show()
+        if not (p.haslayer(TLSRecord) and p[TLSRecord].content_type==TLSContentType.APPLICATION_DATA):
+            raise self.ERROR(p)
+        raise self.CLIENT_APPDATA_RECV(p)
+    
+    @ATMT.state()
+    def CLIENT_APPDATA_RECV(self):
+        pass
+    
+    @ATMT.condition(CLIENT_APPDATA_RECV)
+    def send_server_response(self):
+        raise self.SERVER_APPDATA_SENT()
+    
+    @ATMT.action(send_server_response)
+    def do_send_server_response(self):
+        self.tlssock.sendall(to_raw(TLSPlaintext(data=self.response), self.tlssock.tls_ctx))
+    
+    @ATMT.state()
+    def SERVER_APPDATA_SENT(self):
+        raise self.END()
+    
+    # GENERIC ERROR - print received data if available
+    @ATMT.state(error=1)
+    def ERROR(self, p=None):
+        if p:
+            p.show()
+        return
+    
+    # GENERIC END - return server's response
+    @ATMT.state(final=1)
+    def END(self, p):
+        return ''.join(pkt[TLSPlaintext].data for pkt in p.records)

--- a/scapy_ssl_tls/ssl_tls_automata.py
+++ b/scapy_ssl_tls/ssl_tls_automata.py
@@ -195,22 +195,31 @@ class TLSServerAutomata(Automaton):
         auto_srv.run()
     """
     def parse_args(self, 
-                   target, 
-                   tls_version='TLS_1_1', 
+                   bind, 
+                   pemcert,
+                   pemkey=None,
                    response="HTTP/1.1 200 OK\r\n\r\n", 
                    cipher_suite=TLSCipherSuite.RSA_WITH_AES_128_CBC_SHA,
                    timeout=4.0, 
                    **kwargs):
         Automaton.parse_args(self, **kwargs)
-        self.target = target
-        self.tls_version = tls_version
+        self.bind = bind
+        self.pemcert = pemcert
+        self.pemkey = pemkey if pemkey else pemcert
+        self.tls_version = 'TLS_1_2'
         self.response = response
         self.cipher_suite = cipher_suite
         self.timeout = timeout
         self.tlssock = None
         self.srv_sock = None
         self.peer = None
+        
+        pemo = pem_get_objects(self.pemcert)
+        for key_pk in (k for k in pemo.keys() if "CERTIFICATE" in k.upper()):
+            self.dercert = ''.join(line for line in pemo[key_pk].get("full").strip().split("\n") if not "-" in line).decode("base64")
+            break
         self.debug(1,"parse_args - done")
+        
 
     # GENERIC BEGIN
     @ATMT.state(initial=1)
@@ -223,18 +232,23 @@ class TLSServerAutomata(Automaton):
     
     @ATMT.action(listen)
     def do_bind(self):
-        self.debug(1,"dobind")
+        self.debug(1,"dobind %s "%repr(self.bind))
         self.srv_sock = socket.socket(socket.AF_INET,socket.SOCK_STREAM)
-        self.srv_sock.bind(self.target)
-        self.srv_sock.listen(1)
+        self.srv_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, True)
+        self.srv_tls_sock = TLSSocket(self.srv_sock, client=False)
+        self.srv_tls_sock.bind(self.bind)
+        self.srv_tls_sock.listen(1)
         
-        self.debug(1,"server bound to %s:%d"%self.target)
+        pemo = pem_get_objects(self.pemkey)
+        for key_pk in (k for k in pemo.keys() if "PRIVATE" in k.upper()):
+            self.srv_tls_sock.tls_ctx.crypto.server.rsa.privkey, self.srv_tls_sock.tls_ctx.crypto.server.rsa.pubkey = self.srv_tls_sock.tls_ctx._rsa_load_keys(pemo[key_pk].get("full"))
+            break
         
     @ATMT.state()
     def WAIT_FOR_CLIENT_CONNECTION(self):
         self.debug(1,"accept")
-        self.peer = self.srv_sock.accept()
-        self.tlssock = TLSSocket(self.peer[0], client=False)
+        self.tlssock, self.peer = self.srv_tls_sock.accept()
+        self.debug(1,"new connection: %s"%repr(self.peer))
     
     @ATMT.condition(WAIT_FOR_CLIENT_CONNECTION)
     def recv_client_hello(self):
@@ -242,6 +256,7 @@ class TLSServerAutomata(Automaton):
         p.show()
         if not p.haslayer(TLSClientHello):
             raise self.ERROR(p)
+        self.tls_version = p[TLSClientHello].version
         raise self.CLIENT_HELLO_RECV()
     
     @ATMT.state()
@@ -261,15 +276,8 @@ class TLSServerAutomata(Automaton):
         server_hello.show()
         self.tlssock.sendall(server_hello)
         
-        #TODO: remove static server cert/key 
-        #pem = ssl_tls_crypto.pem_get_objects(open("../tests/files/openssl_1_0_1_f_server.pem",'r').read())
         
-        #key = pem['RSA PRIVATE KEY']['full'].replace("\n","")
-        key = "MIIEpAIBAAKCAQEA84TzkjbcskbKZnrlKcXzSSgi07n+4N7kOM7uIhzpkTuU0HIvh4VZS2axxfV6hV3CD9MuKVg2zEhroqK1Js5n4ke230nSP/qiELfCl0R+hzRtbfKLtFUr1iHeU0uQ6v3q+Tg1K/Tmmg72uxKrhyHDL7z0BriPjhAHJ5XlQsvR1RCMkqzuD9wjSInJxpMMIgLndOclAKv4D1wQtYU7ZpTw+01XBlUhIiXb86qpYL9NqnnRq5JIuhmOEuxo2ca63+xaHNhD/udSyc8C0Md/yX6wlONTRFgLLv0pdLUGm1xEjfsydaQ6qGd7hzIKUI3hohNKJa/mHLElv7SZolPTogK/EQIDAQABAoIBAADq9FwNtuE5IRQnzGtO4q7Y5uCzZ8GDNYr9RKp+P2cbuWDbvVAecYq2NV9QoIiWJOAYZKklOvekIju3r0UZLA0PRiIrTg6NrESx3JrjWDK8QNlUO7CPTZ39/K+FrmMkV9lem9yxjJjyC34DAQB+YRTx+l14HppjdxNwHjAVQpIx/uO2F5xAMuk32+3K+pq9CZUtrofe1q4Agj9R5s8mSy9pbRo9kW9wl5xdEotz1LivFOEiqPUJTUq5J5PeMKao3vdK726XI4Z455NmW2/MA0YV0ug2FYinHcZdvKM6dimH8GLfa3X8xKRfzjGjTiMSwsdjgMa4awY3tEHH674jhAECgYEA/zqMrc0zsbNk83sjgaYIug5kzEpN4ic020rSZsmQxSCerJTgNhmgutKSCt0Re09Jt3LqG48msahX8ycqDsHNvlEGPQSbMu9IYeO3Wr3fAm75GEtFWePYBhM73I7gkRt4s8bUiUepMG/wY45c5tRF23xi8foReHFFe9MDzh8fJFECgYEA9EFX4qAik1pOJGNei9BMwmx0I0gfVEIgu0tzeVqT45vcxbxr7RkTEaDoAG6PlbWP6D9aWQNLp4gsgRM90ZXOJ4up5DsAWDluvaF4/omabMA+MJJ5kGZ0gCj5rbZbKqUws7x8bp+6iBfUPJUbcqNqFmi/08Yt7vrDnMnyMw2A/sECgYEAiiuRMxnuzVm34hQcsbhH6ymVqf7j0PW2qK0F4H1ocT9qhzWFd+RB3kHWrCjnqODQoI6GbGr/4JepHUpre1ex4UEN5oSS3G0ru0rC3U4C59dZ5KwDHFm7ffZ1pr52ljfQDUsrjjIMRtuiwNK2OoRaWSsqiaL+SDzSB+nBmpnAizECgYBdt/y6rerWUx4MhDwwtTnel7JwHyo2MDFS6/5gn8qC2Lj6/fMDRE22w+CA2esp7EJNQJGv+b27iFpbJEDh+/Lf5YzIT4MwVskQ5bYBJFcmRxUVmf4e09D7o705U/DjCgMH09iCsbLmqQ38ONIRSHZaJtMDtNTHD1yi+jF+OT43gQKBgQC/2OHZoko6iRlNOAQ/tMVFNq7fL81GivoQ9F1U0Qr+DH3ZfaH8eIkXxT0ToMPJUzWAn8pZv0snA0um6SIgvkCuxO84OkANCVbttzXImIsL7pFzfcwV/ERKUM6j0ZuSMFOCr/lGPAoOQU0fskidGEHi1/kW+suSr28TqsyYZpwBDQ==".decode("base64")
-        #cert = pem['CERTIFICATE']['full'].replace("\n","")
-        cert = "MIID5zCCAs+gAwIBAgIJALnu1NlVpZ6zMA0GCSqGSIb3DQEBBQUAMHAxCzAJBgNVBAYTAlVLMRYwFAYDVQQKDA1PcGVuU1NMIEdyb3VwMSIwIAYDVQQLDBlGT1IgVEVTVElORyBQVVJQT1NFUyBPTkxZMSUwIwYDVQQDDBxPcGVuU1NMIFRlc3QgSW50ZXJtZWRpYXRlIENBMB4XDTExMTIwODE0MDE0OFoXDTIxMTAxNjE0MDE0OFowZDELMAkGA1UEBhMCVUsxFjAUBgNVBAoMDU9wZW5TU0wgR3JvdXAxIjAgBgNVBAsMGUZPUiBURVNUSU5HIFBVUlBPU0VTIE9OTFkxGTAXBgNVBAMMEFRlc3QgU2VydmVyIENlcnQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDzhPOSNtyyRspmeuUpxfNJKCLTuf7g3uQ4zu4iHOmRO5TQci+HhVlLZrHF9XqFXcIP0y4pWDbMSGuiorUmzmfiR7bfSdI/+qIQt8KXRH6HNG1t8ou0VSvWId5TS5Dq/er5ODUr9OaaDva7EquHIcMvvPQGuI+OEAcnleVCy9HVEIySrO4P3CNIicnGkwwiAud05yUAq/gPXBC1hTtmlPD7TVcGVSEiJdvzqqlgv02qedGrkki6GY4S7GjZxrrf7Foc2EP+51LJzwLQx3/JfrCU41NEWAsu/Sl0tQabXESN+zJ1pDqoZ3uHMgpQjeGiE0olr+YcsSW/tJmiU9OiAr8RAgMBAAGjgY8wgYwwDAYDVR0TAQH/BAIwADAOBgNVHQ8BAf8EBAMCBeAwLAYJYIZIAYb4QgENBB8WHU9wZW5TU0wgR2VuZXJhdGVkIENlcnRpZmljYXRlMB0GA1UdDgQWBBSCvM8AABPR9zklmifnr9LvIBturDAfBgNVHSMEGDAWgBQ2w2yI55X+sL3szj49hqshgYfa2jANBgkqhkiG9w0BAQUFAAOCAQEAqb1NV0B0/pbpK9Z4/bNjzPQLTRLKWnSNm/Jh5v0GEUOE/Beg7GNjNrmeNmqxAlpqWz9qoeoFZax+QBpIZYjROU3TS3fpyLsrnlr0CDQ5R7kCCDGa8dkXxemmpZZLbUCpW2Uoy8sAA4JjN9OtsZY7dvUXFgJ7vVNTRnI01ghknbtD+2SxSQd3CWF6QhcRMAzZJ1z1cbbwGDDzfvGFPzJ+Sq+zEPdsxoVLLSetCiBc+40ZcDS5dV98h9XD7JMTQfxzA7mNGv73JoZJA6nFgj+ADSlJsY/tJBv+z1iQRueoh9Qeee+ZbRifPouCB8FDx+AltvHTANdAq0t/K3o+pplMVA==".decode("base64")
-
-        server_certificates = rec_hs / TLSCertificateList(certificates=[TLSCertificate(data=x509.X509Cert(cert))])
+        server_certificates = rec_hs / TLSCertificateList(certificates=[TLSCertificate(data=x509.X509Cert(self.dercert))])
         server_certificates.show()
         self.tlssock.sendall(server_certificates)
         (rec_hs / TLSServerHelloDone()).show2()
@@ -330,11 +338,21 @@ class TLSServerAutomata(Automaton):
     
     @ATMT.condition(SERVER_FINISH_SENT)
     def recv_client_appdata(self):
-        p = self.tlssock.recvall()
+        chunk_p = True
+        p = SSL()
+        self.debug(1,"polling in 5sec intervals until data arrives.")
+        while chunk_p:
+            chunk_p = self.tlssock.recvall(timeout=5)
+            if (chunk_p.haslayer(SSL) and len(chunk_p[SSL].records)>0):
+                p.records.append(chunk_p)
+            else:
+                if len(p[SSL].records)>0:
+                    break
+            
         p.show()
         if not (p.haslayer(TLSRecord) and p[TLSRecord].content_type==TLSContentType.APPLICATION_DATA):
             raise self.ERROR(p)
-        raise self.CLIENT_APPDATA_RECV(p)
+        raise self.CLIENT_APPDATA_RECV()
     
     @ATMT.state()
     def CLIENT_APPDATA_RECV(self):
@@ -361,5 +379,5 @@ class TLSServerAutomata(Automaton):
     
     # GENERIC END - return server's response
     @ATMT.state(final=1)
-    def END(self, p):
-        return ''.join(pkt[TLSPlaintext].data for pkt in p.records)
+    def END(self):
+        self.tlssock.sendall(to_raw(TLSAlert(level=TLSAlertLevel.WARNING, description=TLSAlertDescription.CLOSE_NOTIFY), self.tlssock.tls_ctx))


### PR DESCRIPTION
since @alexmgr provided the missing ingredient for server mode tlssockets here's a basic server automata. Atm. it is polling the client in a 5s interval for data, will have to change that in future versions.

    TLSServerAutomata.graph()
![scapy2](https://cloud.githubusercontent.com/assets/2865694/12966809/80b2361e-d061-11e5-91d2-72db52481440.png)

#### start the server:

    auto_srv = TLSServerAutomata(debug=9,
                             bind=('0.0.0.0', 8443),
                             pemcert=pemcert,
                             cipher_suite=TLSCipherSuite.RSA_WITH_AES_128_CBC_SHA,
                             response="HTTP/1.1 200 OK\r\n\r\n")
     print auto_srv.run()

#### automata debug log with state transitions:

    WARNING: No route found for IPv6 destination :: (no default route?)
    using certificate/keyfile: ../tests/files/openssl_1_0_1_f_server.pem
    DEBUG: parse_args - done
    DEBUG: parse_args - done
    DEBUG: Starting control thread [tid=8316]
    DEBUG: Received command RUN
    DEBUG: ## state=[BEGIN]
    DEBUG: BEGIN
    DEBUG: Trying Condition [listen]
    DEBUG: Condition [listen] taken to state [WAIT_FOR_CLIENT_CONNECTION]
    DEBUG:    + Running action [do_bind]
    DEBUG: dobind ('0.0.0.0', 8443) 
    DEBUG: switching from [BEGIN] to [WAIT_FOR_CLIENT_CONNECTION]
    DEBUG: ## state=[WAIT_FOR_CLIENT_CONNECTION]
    DEBUG: accept
    DEBUG: new connection: ('192.168.139.1', 10640)
    DEBUG: Trying Condition [recv_client_hello]
    ###[ SSL/TLS ]###
      \records   \
       |###[ TLS Record ]###
       |  content_type= handshake
       |  version   = TLS_1_0
       |  length    = 0x12d
       |###[ TLS Handshake ]###
       |     type      = client_hello
       |     length    = 0x129
       |###[ TLS Client Hello ]###
       |        version   = TLS_1_2
       |        gmt_unix_time= 1622420732
       |        random_bytes= '\x83\xf1|3\x19\x9bj\xc2!\xbe\xe2"\x16\rw\xaf&\xbc!Cl1$\xe2\x9c\xab\x9f+'
       |        session_id_length= 0x0
       |        session_id= ''
       |        cipher_suites_length= 0x92
       |        cipher_suites= ['ECDHE_RSA_WITH_AES_256_GCM_SHA384', 'ECDHE_ECDSA_WITH_AES_256_GCM_SHA384', 'ECDHE_RSA_WITH_AES_256_CBC_SHA384', 'ECDHE_ECDSA_WITH_AES_256_CBC_SHA384', 'ECDHE_RSA_WITH_AES_256_CBC_SHA', 'ECDHE_ECDSA_WITH_AES_256_CBC_SHA', 'DHE_DSS_WITH_AES_256_GCM_SHA384', 'DHE_RSA_WITH_AES_256_GCM_SHA384', 'DHE_RSA_WITH_AES_256_CBC_SHA256', 'DHE_DSS_WITH_AES_256_CBC_SHA256', 'DHE_RSA_WITH_AES_256_CBC_SHA', 'DHE_DSS_WITH_AES_256_CBC_SHA', 'DHE_RSA_WITH_CAMELLIA_256_CBC_SHA', 'DHE_DSS_WITH_CAMELLIA_256_CBC_SHA', 'ECDH_RSA_WITH_AES_256_GCM_SHA384', 'ECDH_ECDSA_WITH_AES_256_GCM_SHA384', 'ECDH_RSA_WITH_AES_256_CBC_SHA384', 'ECDH_ECDSA_WITH_AES_256_CBC_SHA384', 'ECDH_RSA_WITH_AES_256_CBC_SHA', 'ECDH_ECDSA_WITH_AES_256_CBC_SHA', 'RSA_WITH_AES_256_GCM_SHA384', 'RSA_WITH_AES_256_CBC_SHA256', 'RSA_WITH_AES_256_CBC_SHA', 'RSA_WITH_CAMELLIA_256_CBC_SHA', 'ECDHE_RSA_WITH_AES_128_GCM_SHA256', 'ECDHE_ECDSA_WITH_AES_128_GCM_SHA256', 'ECDHE_RSA_WITH_AES_128_CBC_SHA256', 'ECDHE_ECDSA_WITH_AES_128_CBC_SHA256', 'ECDHE_RSA_WITH_AES_128_CBC_SHA', 'ECDHE_ECDSA_WITH_AES_128_CBC_SHA', 'DHE_DSS_WITH_AES_128_GCM_SHA256', 'DHE_RSA_WITH_AES_128_GCM_SHA256', 'DHE_RSA_WITH_AES_128_CBC_SHA256', 'DHE_DSS_WITH_AES_128_CBC_SHA256', 'DHE_RSA_WITH_AES_128_CBC_SHA', 'DHE_DSS_WITH_AES_128_CBC_SHA', 'DHE_RSA_WITH_SEED_CBC_SHA', 'DHE_DSS_WITH_SEED_CBC_SHA', 'DHE_RSA_WITH_CAMELLIA_128_CBC_SHA', 'DHE_DSS_WITH_CAMELLIA_128_CBC_SHA', 'ECDH_RSA_WITH_AES_128_GCM_SHA256', 'ECDH_ECDSA_WITH_AES_128_GCM_SHA256', 'ECDH_RSA_WITH_AES_128_CBC_SHA256', 'ECDH_ECDSA_WITH_AES_128_CBC_SHA256', 'ECDH_RSA_WITH_AES_128_CBC_SHA', 'ECDH_ECDSA_WITH_AES_128_CBC_SHA', 'RSA_WITH_AES_128_GCM_SHA256', 'RSA_WITH_AES_128_CBC_SHA256', 'RSA_WITH_AES_128_CBC_SHA', 'RSA_WITH_SEED_CBC_SHA', 'RSA_WITH_CAMELLIA_128_CBC_SHA', 'ECDHE_RSA_WITH_RC4_128_SHA', 'ECDHE_ECDSA_WITH_RC4_128_SHA', 'ECDH_RSA_WITH_RC4_128_SHA', 'ECDH_ECDSA_WITH_RC4_128_SHA', 'RSA_WITH_RC4_128_SHA', 'RSA_WITH_RC4_128_MD5', 'ECDHE_RSA_WITH_3DES_EDE_CBC_SHA', 'ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA', 'DHE_RSA_WITH_3DES_EDE_CBC_SHA', 'DHE_DSS_WITH_3DES_EDE_CBC_SHA', 'ECDH_RSA_WITH_3DES_EDE_CBC_SHA', 'ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA', 'RSA_WITH_3DES_EDE_CBC_SHA', 'DHE_RSA_WITH_DES_CBC_SHA', 'DHE_DSS_WITH_DES_CBC_SHA', 'RSA_WITH_DES_CBC_SHA', 'DHE_RSA_EXPORT_WITH_DES40_CBC_SHA', 'DHE_DSS_EXPORT_WITH_DES40_CBC_SHA', 'RSA_EXPORT_WITH_DES40_CBC_SHA', 'RSA_EXPORT_WITH_RC2_CBC_40_MD5', 'RSA_EXPORT_WITH_RC4_40_MD5', 'EMPTY_RENEGOTIATION_INFO_SCSV']
       |        compression_methods_length= 0x2
       |        compression_methods= ['DEFLATE', 'NULL']
       |        extensions_length= 0x6d
       |        \extensions\
       |         |###[ TLS Extension ]###
       |         |  type      = ec_point_formats
       |         |  length    = 0x4
       |         |###[ TLS Extension EC Points Format ]###
       |         |     length    = 0x3
       |         |     ec_point_formats= ['uncompressed', 'ansiX962_compressed_prime', 'ansiX962_compressed_char2']
       |         |###[ TLS Extension ]###
       |         |  type      = supported_groups
       |         |  length    = 0x34
       |         |###[ TLS Extension Elliptic Curves ]###
       |         |     length    = 0x32
       |         |     elliptic_curves= ['sect571r1', 'sect571k1', 'secp521r1', 'sect409k1', 'sect409r1', 'secp384r1', 'sect283k1', 'sect283r1', 'secp256k1', 'secp256r1', 'sect239k1', 'sect233k1', 'sect233r1', 'secp224k1', 'secp224r1', 'sect193r1', 'sect193r2', 'secp192k1', 'secp192r1', 'sect163k1', 'sect163r1', 'sect163r2', 'secp160k1', 'secp160r1', 'secp160r2']
       |         |###[ TLS Extension ]###
       |         |  type      = SessionTicket_TLS
       |         |  length    = 0x0
       |         |###[ TLS Extension ]###
       |         |  type      = signature_algorithms
       |         |  length    = 0x20
       |         |###[ TLS Extension Signature And Hash Algorithm ]###
       |         |     length    = 0x1e
       |         |     \algorithms\
       |         |      |###[ TLS Signature Hash Algorithm Pair ]###
       |         |      |  hash_algorithm= sha512
       |         |      |  signature_algorithm= rsa
       |         |      |###[ TLS Signature Hash Algorithm Pair ]###
       |         |      |  hash_algorithm= sha512
       |         |      |  signature_algorithm= dsa
       |         |      |###[ TLS Signature Hash Algorithm Pair ]###
       |         |      |  hash_algorithm= sha512
       |         |      |  signature_algorithm= ecdsa
       |         |      |###[ TLS Signature Hash Algorithm Pair ]###
       |         |      |  hash_algorithm= sha384
       |         |      |  signature_algorithm= rsa
       |         |      |###[ TLS Signature Hash Algorithm Pair ]###
       |         |      |  hash_algorithm= sha384
       |         |      |  signature_algorithm= dsa
       |         |      |###[ TLS Signature Hash Algorithm Pair ]###
       |         |      |  hash_algorithm= sha384
       |         |      |  signature_algorithm= ecdsa
       |         |      |###[ TLS Signature Hash Algorithm Pair ]###
       |         |      |  hash_algorithm= sha256
       |         |      |  signature_algorithm= rsa
       |         |      |###[ TLS Signature Hash Algorithm Pair ]###
       |         |      |  hash_algorithm= sha256
       |         |      |  signature_algorithm= dsa
       |         |      |###[ TLS Signature Hash Algorithm Pair ]###
       |         |      |  hash_algorithm= sha256
       |         |      |  signature_algorithm= ecdsa
       |         |      |###[ TLS Signature Hash Algorithm Pair ]###
       |         |      |  hash_algorithm= sha224
       |         |      |  signature_algorithm= rsa
       |         |      |###[ TLS Signature Hash Algorithm Pair ]###
       |         |      |  hash_algorithm= sha224
       |         |      |  signature_algorithm= dsa
       |         |      |###[ TLS Signature Hash Algorithm Pair ]###
       |         |      |  hash_algorithm= sha224
       |         |      |  signature_algorithm= ecdsa
       |         |      |###[ TLS Signature Hash Algorithm Pair ]###
       |         |      |  hash_algorithm= sha1
       |         |      |  signature_algorithm= rsa
       |         |      |###[ TLS Signature Hash Algorithm Pair ]###
       |         |      |  hash_algorithm= sha1
       |         |      |  signature_algorithm= dsa
       |         |      |###[ TLS Signature Hash Algorithm Pair ]###
       |         |      |  hash_algorithm= sha1
       |         |      |  signature_algorithm= ecdsa
       |         |###[ TLS Extension ]###
       |         |  type      = heartbeat
       |         |  length    = 0x1
       |         |###[ TLS Extension HeartBeat ]###
       |         |     mode      = peer_allowed_to_send
    DEBUG: Condition [recv_client_hello] taken to state [CLIENT_HELLO_RECV]
    ###[ TLS Record ]###
      content_type= handshake
      version   = TLS_1_2
      length    = None
    ###[ TLS Handshake ]###
         type      = server_hello
         length    = None
    ###[ TLS Server Hello ]###
            version   = TLS_1_2
            gmt_unix_time= 1455151322
            random_bytes= 'gaw\xea\x8d.\xb0\x0f\xd6\xc8\xe9\x10\xc2(8\x8e\xcd\xcc\xd0\xe7\x0f\x9f\xaa\x1a\xb4\xb5\xc8_'
            session_id_length= None
            session_id= 'e\x12\x05N\xc2\xba\xde\x07\x88\xdd\x87\xe4\xd9:\xcfc\x9b\xec\xadR'
            cipher_suite= RSA_WITH_AES_128_CBC_SHA
            compression_method= NULL
            \extensions\
    DEBUG: switching from [WAIT_FOR_CLIENT_CONNECTION] to [CLIENT_HELLO_RECV]
    DEBUG: ## state=[CLIENT_HELLO_RECV]
    DEBUG: Trying Condition [send_server_hello]
    DEBUG: Condition [send_server_hello] taken to state [SERVER_HELLO_SENT]
    DEBUG:    + Running action [do_send_server_hello]
    ###[ TLS Record ]###
      content_type= handshake
      version   = TLS_1_2
      length    = None
    ###[ TLS Handshake ]###
         type      = certificate
         length    = None
    ###[ TLS Certificate List ]###
            length    = None
            \certificates\
             |###[ TLS Certificate ]###
             |  length    = None
             |  \data      \
             |   |###[ X509Cert ]###
             |   |  version   = <ASN1_INTEGER[2L]>
             |   |  sn        = <ASN1_INTEGER[13397879971383713459L]>
             |   |  sign_algo = <ASN1_OID['.1.2.840.113549.1.1.5']>
             |   |  sa_value  = <ASN1_NULL[0L]>
             |   |  \issuer    \
             |   |   |###[ X509RDN ]###
             |   |   |  oid       = <ASN1_OID['.2.5.4.6']>
             |   |   |  value     = <ASN1_PRINTABLE_STRING['UK']>
             |   |   |###[ X509RDN ]###
             |   |   |  oid       = <ASN1_OID['.2.5.4.10']>
             |   |   |  value     = <ASN1_BADTAG[<ASN1_DECODING_ERROR['\x0c\rOpenSSL Group']{{Codec <ASN1Codec BER[1]> not found for tag <ASN1Tag UTF8_STRING[12]>}}>]>
             |   |   |###[ X509RDN ]###
             |   |   |  oid       = <ASN1_OID['.2.5.4.11']>
             |   |   |  value     = <ASN1_BADTAG[<ASN1_DECODING_ERROR['\x0c\x19FOR TESTING PURPOSES ONLY']{{Codec <ASN1Codec BER[1]> not found for tag <ASN1Tag UTF8_STRING[12]>}}>]>
             |   |   |###[ X509RDN ]###
             |   |   |  oid       = <ASN1_OID['.2.5.4.3']>
             |   |   |  value     = <ASN1_BADTAG[<ASN1_DECODING_ERROR['\x0c\x1cOpenSSL Test Intermediate CA']{{Codec <ASN1Codec BER[1]> not found for tag <ASN1Tag UTF8_STRING[12]>}}>]>
             |   |  not_before= <ASN1_UTC_TIME['111208140148Z']>
             |   |  not_after = <ASN1_UTC_TIME['211016140148Z']>
             |   |  \subject   \
             |   |   |###[ X509RDN ]###
             |   |   |  oid       = <ASN1_OID['.2.5.4.6']>
             |   |   |  value     = <ASN1_PRINTABLE_STRING['UK']>
             |   |   |###[ X509RDN ]###
             |   |   |  oid       = <ASN1_OID['.2.5.4.10']>
             |   |   |  value     = <ASN1_BADTAG[<ASN1_DECODING_ERROR['\x0c\rOpenSSL Group']{{Codec <ASN1Codec BER[1]> not found for tag <ASN1Tag UTF8_STRING[12]>}}>]>
             |   |   |###[ X509RDN ]###
             |   |   |  oid       = <ASN1_OID['.2.5.4.11']>
             |   |   |  value     = <ASN1_BADTAG[<ASN1_DECODING_ERROR['\x0c\x19FOR TESTING PURPOSES ONLY']{{Codec <ASN1Codec BER[1]> not found for tag <ASN1Tag UTF8_STRING[12]>}}>]>
             |   |   |###[ X509RDN ]###
             |   |   |  oid       = <ASN1_OID['.2.5.4.3']>
             |   |   |  value     = <ASN1_BADTAG[<ASN1_DECODING_ERROR['\x0c\x10Test Server Cert']{{Codec <ASN1Codec BER[1]> not found for tag <ASN1Tag UTF8_STRING[12]>}}>]>
             |   |  pubkey_algo= <ASN1_OID['.1.2.840.113549.1.1.1']>
             |   |  pk_value  = <ASN1_NULL[0L]>
             |   |  pubkey    = <ASN1_BIT_STRING['\x000\x82\x01\n\x02\x82\x01\x01\x00\xf3\x84\xf3\x926\xdc\xb2F\xcafz\xe5)\xc5\xf3I("\xd3\xb9\xfe\xe0\xde\xe48\xce\xee"\x1c\xe9\x91;\x94\xd0r/\x87\x85YKf\xb1\xc5\xf5z\x85]\xc2\x0f\xd3.)X6\xccHk\xa2\xa2\xb5&\xceg\xe2G\xb6\xdfI\xd2?\xfa\xa2\x10\xb7\xc2\x97D~\x874mm\xf2\x8b\xb4U+\xd6!\xdeSK\x90\xea\xfd\xea\xf985+\xf4\xe6\x9a\x0e\xf6\xbb\x12\xab\x87!\xc3/\xbc\xf4\x06\xb8\x8f\x8e\x10\x07\'\x95\xe5B\xcb\xd1\xd5\x10\x8c\x92\xac\xee\x0f\xdc#H\x89\xc9\xc6\x93\x0c"\x02\xe7t\xe7%\x00\xab\xf8\x0f\\\x10\xb5\x85;f\x94\xf0\xfbMW\x06U!"%\xdb\xf3\xaa\xa9`\xbfM\xaay\xd1\xab\x92H\xba\x19\x8e\x12\xech\xd9\xc6\xba\xdf\xecZ\x1c\xd8C\xfe\xe7R\xc9\xcf\x02\xd0\xc7\x7f\xc9~\xb0\x94\xe3SDX\x0b.\xfd)t\xb5\x06\x9b\\D\x8d\xfb2u\xa4:\xa8g{\x872\nP\x8d\xe1\xa2\x13J%\xaf\xe6\x1c\xb1%\xbf\xb4\x99\xa2S\xd3\xa2\x02\xbf\x11\x02\x03\x01\x00\x01']>
             |   |  \x509v3ext \
             |   |   |###[ X509v3Ext ]###
             |   |   |  val       = <ASN1_SEQUENCE[[<ASN1_OID['.2.5.29.19']>, <ASN1_BOOLEAN[-1L]>, <ASN1_STRING['0\x00']>]]>
             |   |   |###[ X509v3Ext ]###
             |   |   |  val       = <ASN1_SEQUENCE[[<ASN1_OID['.2.5.29.15']>, <ASN1_BOOLEAN[-1L]>, <ASN1_STRING['\x03\x02\x05\xe0']>]]>
             |   |   |###[ X509v3Ext ]###
             |   |   |  val       = <ASN1_SEQUENCE[[<ASN1_OID['.2.16.840.1.113730.1.13']>, <ASN1_STRING['\x16\x1dOpenSSL Generated Certificate']>]]>
             |   |   |###[ X509v3Ext ]###
             |   |   |  val       = <ASN1_SEQUENCE[[<ASN1_OID['.2.5.29.14']>, <ASN1_STRING["\x04\x14\x82\xbc\xcf\x00\x00\x13\xd1\xf79%\x9a'\xe7\xaf\xd2\xef \x1bn\xac"]>]]>
             |   |   |###[ X509v3Ext ]###
             |   |   |  val       = <ASN1_SEQUENCE[[<ASN1_OID['.2.5.29.35']>, <ASN1_STRING['0\x16\x80\x146\xc3l\x88\xe7\x95\xfe\xb0\xbd\xec\xce>=\x86\xab!\x81\x87\xda\xda']>]]>
             |   |  sign_algo2= <ASN1_OID['.1.2.840.113549.1.1.5']>
             |   |  sa2_value = <ASN1_NULL[0L]>
             |   |  signature = <ASN1_BIT_STRING["\x00\xa9\xbdMW@t\xfe\x96\xe9+\xd6x\xfd\xb3c\xcc\xf4\x0bM\x12\xcaZt\x8d\x9b\xf2a\xe6\xfd\x06\x11C\x84\xfc\x17\xa0\xeccc6\xb9\x9e6j\xb1\x02Zj[?j\xa1\xea\x05e\xac~@\x1aHe\x88\xd19M\xd3Kw\xe9\xc8\xbb+\x9eZ\xf4\x0849G\xb9\x02\x081\x9a\xf1\xd9\x17\xc5\xe9\xa6\xa5\x96Km@\xa9[e(\xcb\xcb\x00\x03\x82c7\xd3\xad\xb1\x96;v\xf5\x17\x16\x02{\xbdSSFr4\xd6\x08d\x9d\xbbC\xfbd\xb1I\x07w\tazB\x17\x110\x0c\xd9'\\\xf5q\xb6\xf0\x180\xf3~\xf1\x85?2~J\xaf\xb3\x10\xf7l\xc6\x85K-'\xad\n \\\xfb\x8d\x19p4\xb9u_|\x87\xd5\xc3\xec\x93\x13A\xfcs\x03\xb9\x8d\x1a\xfe\xf7&\x86I\x03\xa9\xc5\x82?\x80\r)I\xb1\x8f\xed$\x1b\xfe\xcfX\x90F\xe7\xa8\x87\xd4\x1ey\xef\x99m\x18\x9f>\x8b\x82\x07\xc1C\xc7\xe0%\xb6\xf1\xd3\x00\xd7@\xabK\x7f+z>\xa6\x99LT"]>
    ###[ TLS Record ]###
      content_type= handshake
      version   = TLS_1_2
      length    = 0x7
    ###[ TLS Handshake ]###
         type      = server_hello_done
         length    = 0x3
    ###[ TLS Server Hello Done ]###
            length    = 0x0
            data      = ''
    DEBUG: switching from [CLIENT_HELLO_RECV] to [SERVER_HELLO_SENT]
    DEBUG: ## state=[SERVER_HELLO_SENT]
    DEBUG: Trying Condition [recv_client_key_exchange]
    ###[ SSL/TLS ]###
      \records   \
       |###[ TLS Record ]###
       |  content_type= handshake
       |  version   = TLS_1_2
       |  length    = 0x106
       |###[ TLS Handshake ]###
       |     type      = client_key_exchange
       |     length    = 0x102
       |     explicit_iv= ''
       |     mac       = ''
       |     padding   = ''
       |###[ TLS Client Key Exchange ]###
       |###[ TLS RSA Client Params ]###
       |           length    = 0x100
       |           data      = '\x8e\xbb\xb9\x94^1>d\x13\xa0\x97\xe1\xdd\xde-\xb1\xa3^\xad\x88\x15(7G)p\x8au:2\xa0?Bog\xa9QkS\x12Y\xa0\xc7\x05/\x92\xa0\x0cB\xb2\x94\xeb\x11\xfd\x07]\x0b\xd9\x0c\xf6G\x06"\xaa\xfa\x12sp&\xe2\xb4\x0f\xab0\x8a\xeb\xbfB\x8fCL\xe0\xae=\xeeip\xb5C\x9f6\x8fOFz.\xae\xc5\xe8\x9b\xeeV\x86J\xde_\xc6\xa9\x13H=\r;\xa4\x05\xc3\xa6O9\xe0s\xee\xed\xf0\xe1\xdf\x1d4o\xe9\xeco\x8c&\x91F\xad\xad\x00\xe8\x97\x05\xb8 \xf0J\xfaD5(\xb2\t\xaa\xc6cQ\xde8)\x0c\xb4A\xda\x1c`\xed\x8a\x8d\x98\x9b7]\xf9&8\xde\xe8SRp\xb1\xd1z \xe6B$\xb2\xc6\xbaKaD\xa8\xb7\xe1\xe5\xf34T\x03\xf6\xf2\xd3\xf7\xf6e\xed\x1d\xaf\xde\xcc\xd8RvH1\xed\x7f\xc2{\x14\xc2\xec\xd3\xd2\xb3,\x8a\xdb\xc3\xacfP\xe1z\xaf\xc2|#\x1e4\x8c\x89\x014ts\xa5L\xcf\xc4DM\xa5\xd4'
       |###[ TLS Record ]###
       |  content_type= change_cipher_spec
       |  version   = TLS_1_2
       |  length    = 0x1
       |###[ TLS ChangeCipherSpec ]###
       |     message   = '\x01'
       |###[ TLS Record ]###
       |  content_type= handshake
       |  version   = TLS_1_2
       |  length    = 0x40
       |###[ TLS Handshake ]###
       |     type      = finished
       |     length    = 0xc
       |     explicit_iv= '\x04\n\x00`v\x1d\xb65\x824k\xedC\x1a\x1f\x9b'
       |     mac       = ' \x05\xe9\xaa\xea\xa1\xcd\x1f:\xdb;\xdf~\xcf\xb8\xf1@\xfe.\xc1'
       |     padding   = '\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b'
       |     padding_len= 0xb
       |###[ TLS Handshake Finished ]###
       |        data      = '\xa0\xb6\xfb\xa1.\x84\x83\xa1UBe\x8c'
    DEBUG: Condition [recv_client_key_exchange] taken to state [CLIENT_KEY_EXCHANGE_RECV]
    DEBUG: switching from [SERVER_HELLO_SENT] to [CLIENT_KEY_EXCHANGE_RECV]
    DEBUG: ## state=[CLIENT_KEY_EXCHANGE_RECV]
    DEBUG: switching from [CLIENT_KEY_EXCHANGE_RECV] to [CLIENT_CHANGE_CIPHERSPEC_RECV]
    DEBUG: ## state=[CLIENT_CHANGE_CIPHERSPEC_RECV]
    DEBUG: switching from [CLIENT_CHANGE_CIPHERSPEC_RECV] to [CLIENT_FINISH_RECV]
    DEBUG: ## state=[CLIENT_FINISH_RECV]
    DEBUG: Trying Condition [send_server_ccs]
    DEBUG: Condition [send_server_ccs] taken to state [SERVER_CCS_SENT]
    DEBUG:    + Running action [do_send_server_ccs]
    DEBUG: switching from [CLIENT_FINISH_RECV] to [SERVER_CCS_SENT]
    DEBUG: ## state=[SERVER_CCS_SENT]
    DEBUG: Trying Condition [send_server_finish]
    DEBUG: Condition [send_server_finish] taken to state [SERVER_FINISH_SENT]
    DEBUG:    + Running action [do_send_server_finish]
    DEBUG: switching from [SERVER_CCS_SENT] to [SERVER_FINISH_SENT]
    DEBUG: ## state=[SERVER_FINISH_SENT]
    DEBUG: Trying Condition [recv_client_appdata]
    DEBUG: polling in 5sec intervals until data arrives.
    ###[ SSL/TLS ]###
      \records   \
       |###[ SSL/TLS ]###
       |  \records   \
       |   |###[ TLS Record ]###
       |   |  content_type= application_data
       |   |  version   = TLS_1_2
       |   |  length    = 0x40
       |   |###[ TLS Plaintext ]###
       |   |     data      = 'GET / HTTP/1.1\n'
       |   |     explicit_iv= "\xecQ'I\xd0f2\xbd#\x9aO\x17\xea\x89\x9a]"
       |   |     mac       = '=\x11\xaf\x8d\xdcP\x0f\xdb\xbbY\xea<\x83\xc3$\xd7\xe7\x06\xaag'
       |   |     padding   = '\x0c\x0c\x0c\x0c\x0c\x0c\x0c\x0c\x0c\x0c\x0c\x0c'
       |   |     padding_len= 0xc
       |   |###[ TLS Record ]###
       |   |  content_type= application_data
       |   |  version   = TLS_1_2
       |   |  length    = 0x40
       |   |###[ TLS Plaintext ]###
       |   |     data      = 'Host: localhost\n'
       |   |     explicit_iv= 'G\xb4\xb0IVH\xf2w,\x13\xdd\xf7\x96\x8c0\x0b'
       |   |     mac       = '\x10\xa2\xeb\xe4!O@oY\xe4\x11\xea\xad\xe4\xfd\t\xab\xb6EZ'
       |   |     padding   = '\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b'
       |   |     padding_len= 0xb
       |   |###[ TLS Record ]###
       |   |  content_type= application_data
       |   |  version   = TLS_1_2
       |   |  length    = 0x30
       |   |###[ TLS Plaintext ]###
       |   |     data      = '\n'
       |   |     explicit_iv= '\xa4\x03/>\xe6z\xbb\xc4F(\xfe\x1b\xb1r\r\xa1'
       |   |     mac       = ' u%\x9c\x8bAK\x97\x9awg\xef\x98S\xf7\x01)t\x0e]'
       |   |     padding   = '\n\n\n\n\n\n\n\n\n\n'
       |   |     padding_len= 0xa
    DEBUG: Condition [recv_client_appdata] taken to state [CLIENT_APPDATA_RECV]
    DEBUG: switching from [SERVER_FINISH_SENT] to [CLIENT_APPDATA_RECV]
    DEBUG: ## state=[CLIENT_APPDATA_RECV]
    DEBUG: Trying Condition [send_server_response]
    DEBUG: Condition [send_server_response] taken to state [SERVER_APPDATA_SENT]
    DEBUG:    + Running action [do_send_server_response]
    DEBUG: switching from [CLIENT_APPDATA_RECV] to [SERVER_APPDATA_SENT]
    DEBUG: ## state=[SERVER_APPDATA_SENT]
    DEBUG: switching from [SERVER_APPDATA_SENT] to [END]
    DEBUG: ## state=[END]
    None
    DEBUG: Stopping control thread (tid=8316)

####  client output

    #> openssl s_client -connect 192.168.139.1:8443 -tls1_2
    ...
    New, TLSv1/SSLv3, Cipher is AES128-SHA
    Server public key is 2048 bit
    Secure Renegotiation IS NOT supported
    Compression: NONE
    Expansion: NONE
    SSL-Session:
        Protocol  : TLSv1.2
        Cipher    : AES128-SHA
        Session-ID: 6512054EC2BADE0788DD87E4D93ACF639BECAD52
        Session-ID-ctx:
        Master-Key: 3B9EAC4FA6111AC5F984AA780639DDBFD3361D8E6B4CCA313E4DD6A60DBCF623CA257B3873603B673980DFA9CBA715AC
        Key-Arg   : None
        PSK identity: None
        PSK identity hint: None
        SRP username: None
        Start Time: 1455151800
        Timeout   : 7200 (sec)
        Verify return code: 21 (unable to verify the first certificate)
    ---
    GET / HTTP/1.1
    Host: localhost

    HTTP/1.1 200 OK

    closed
