### PR TITLE
hotfix/v1.2.3 - fix setuptools installing unsupported scapy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -108,18 +108,23 @@ def _post_install(dir_):
                     print(line, end="")
 
 def os_install_requires():
-    dependencies = ["scapy", "pycrypto", "tinyec"]
+    # load dependencies from requirements.txt
+    dependencies = [l.strip() for l in read("requirements.txt").strip().split('\n') if l.strip()]
+    #dependencies = ["scapy>=2.2.0,<2.3.3", "pycrypto", "tinyec"]
     # Scapy on OSX requires dnet and pcapy, but fails to declare them as dependencies
     if platform.system() == "Darwin":
         dependencies.extend(("dnet", "pcapy"))
     return dependencies
 
 def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+    fd = open(os.path.join(os.path.dirname(__file__), fname))
+    data = fd.read()
+    fd.close()
+    return data
 
 setup(
     name="scapy-ssl_tls",
-    version="1.2.3",
+    version="1.2.3.1",
     packages=["scapy_ssl_tls"],
     author="tintinweb",
     author_email="tintinweb@oststrom.com",
@@ -133,7 +138,7 @@ setup(
     long_description=read("README.rst") if os.path.isfile("README.rst") else read("README.md"),
     install_requires=os_install_requires(),
     test_suite="nose.collector",
-    tests_require=["nose", "scapy", "pycrypto", "tinyec"],
+    tests_require=["nose"] + os_install_requires(),
     # Change once virtualenv bug is fixed
     # data_files = get_layer_files_dst(sites=site.getsitepackages())
     data_files=get_layer_files_dst(get_site_packages()),

--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,7 @@ setup(
     license="GPLv2",
     keywords=["scapy", "ssl", "tls", "layer", "network", "dissect", "packets", "decrypt"],
     url="https://github.com/tintinweb/scapy-ssl_tls/",
-    download_url="https://github.com/tintinweb/scapy-ssl_tls/tarball/v1.2.3",
+    download_url="https://github.com/tintinweb/scapy-ssl_tls/tarball/v1.2.3.1",
     # generate rst from .md:  pandoc --from=markdown --to=rst README.md -o README.rst (fix diff section and footer)
     long_description=read("README.rst") if os.path.isfile("README.rst") else read("README.md"),
     install_requires=os_install_requires(),


### PR DESCRIPTION
fixes #79 

* dependencies are now stored in one place (requirements.txt)
* fixes fd leak

- [x] local test: `pip install .`
- [x] testpypi
- [x] release as v1.2.3.1
- [x] merge master (even though it should have been the other way round ;) )

`pip install .`

      tin@ubuntu-tin:~/scapy-ssl_tls$ pip install .
      Processing /home/tin/scapy-ssl_tls
      Collecting pycrypto>=2.6 (from scapy-ssl-tls===1.2.3.1)
        Downloading pycrypto-2.6.1.tar.gz (446kB)
          100% |¦¦¦¦¦¦¦¦¦¦¦¦¦¦¦¦¦¦¦¦¦¦¦¦¦¦¦¦¦¦¦¦| 450kB 732kB/s
      Collecting scapy<2.3.3,>=2.2.0 (from scapy-ssl-tls===1.2.3.1)
        Downloading scapy-2.3.2.tar.gz (1.1MB)
          100% |¦¦¦¦¦¦¦¦¦¦¦¦¦¦¦¦¦¦¦¦¦¦¦¦¦¦¦¦¦¦¦¦| 1.1MB 142kB/s
      Collecting tinyec>=0.3.1 (from scapy-ssl-tls===1.2.3.1)
        Downloading tinyec-0.3.1.tar.gz
      Building wheels for collected packages: scapy-ssl-tls, pycrypto, scapy, tinyec
        Running setup.py bdist_wheel for scapy-ssl-tls ... done
        Stored in directory: /home/tin/.cache/pip/wheels/99/d6/d0/7a6d3c3bdc35182d47dee6cc230244a63de4570828578133bc
        Running setup.py bdist_wheel for pycrypto ... done
        Stored in directory: /home/tin/.cache/pip/wheels/80/1f/94/f76e9746864f198eb0e304aeec319159fa41b082f61281ffce
        Running setup.py bdist_wheel for scapy ... done
        Stored in directory: /home/tin/.cache/pip/wheels/64/d1/83/e38a1301a91516ccb19ad5177ff874fae13889a16dc40d7b0f
        Running setup.py bdist_wheel for tinyec ... done
        Stored in directory: /home/tin/.cache/pip/wheels/a9/a3/06/83aad0e18fe30b85290c903b7901f77b2fa38469a7d3256c09
      Successfully built scapy-ssl-tls pycrypto scapy tinyec
      Installing collected packages: pycrypto, scapy, tinyec, scapy-ssl-tls
      Successfully installed pycrypto scapy scapy-ssl-tls-1.2.3.1 tinyec-0.3.1

// I've created a v1.2.3 hotfix branch `release/1.2.3` until we release `v1.3.0`
