### PR TITLE
fixes #91 - wrong definition of TLSServerHelloDone

### DIFF
--- a/scapy_ssl_tls/ssl_tls.py
+++ b/scapy_ssl_tls/ssl_tls.py
@@ -580,8 +580,7 @@ class TLSServerKeyExchange(TLSKeyExchange):
 
 class TLSServerHelloDone(PacketNoPayload):
     name = "TLS Server Hello Done"
-    fields_desc = [XBLenField("length", None, length_of="data", fmt="!I", numbytes=3),
-                   StrLenField("data", "", length_from=lambda x:x.length)]
+    fields_desc = []
 
 
 class TLSCertificate(PacketNoPayload):

--- a/scapy_ssl_tls/ssl_tls_automata.py
+++ b/scapy_ssl_tls/ssl_tls_automata.py
@@ -457,8 +457,7 @@ class TLSServerAutomata(Automaton):
     @ATMT.action(send_server_hello_done)
     def do_send_server_hello_done(self):
         rec_hs = TLSRecord(version=self.tls_version) / TLSHandshake()
-        (rec_hs / TLSServerHelloDone()).show2()
-        server_hello_done = TLSRecord(version=self.tls_version) / TLSHandshake(type=TLSHandshakeType.SERVER_HELLO_DONE)
+        server_hello_done = TLSRecord(version=self.tls_version) / TLSHandshake() / TLSServerHelloDone()
         self.tlssock.sendall(server_hello_done)
     
     @hookable


### PR DESCRIPTION
see #91 

- [x] cherry-pick from tls1.3 (https://github.com/tintinweb/scapy-ssl_tls/pull/85/commits/ff842dba746e65e0c47569cfcba20c94f77ef992)
