### PR TITLE
Fixed: dnet PYPI dependency is broken

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ def os_install_requires():
     #dependencies = ["scapy>=2.2.0,<2.3.3", "pycrypto", "tinyec"]
     # Scapy on OSX requires dnet and pcapy, but fails to declare them as dependencies
     if platform.system() == "Darwin":
-        dependencies.extend(("dnet", "pcapy"))
+        dependencies.extend(("pydumbnet", "pcapy"))
     return dependencies
 
 


### PR DESCRIPTION
Problem appears at least in MacOS 10.10 and CentOS 6.8 (with python 2.7). pydumbnet is ok.

```
$ pip2.7 install dnet
Collecting dnet
  Could not find a version that satisfies the requirement dnet (from versions: )
No matching distribution found for dnet
```