### PR TITLE
changed "algorithms" to "algs" in SignatureExt

### DIFF
--- a/scapy_ssl_tls/ssl_tls.py
+++ b/scapy_ssl_tls/ssl_tls.py
@@ -417,7 +417,7 @@ class TLSSignatureHashAlgorithm(PacketNoPayload):
 class TLSExtSignatureAndHashAlgorithm(PacketNoPayload):
     name = "TLS Extension Signature And Hash Algorithm"
     fields_desc = [
-                   XFieldLenField("length", None, length_of="algorithms", fmt="H"),
+                   XFieldLenField("length", None, length_of="algs", fmt="H"),
                    PacketListField("algs", None, TLSSignatureHashAlgorithm, length_from=lambda x:x.length),
                   ]
 


### PR DESCRIPTION
changed TLSExtSignatureAndHashAlgorithm to search for "algs" attribute.

it gave me Attribute error: algorithms

now it works with release 1.2.3 and scapy 2.3.2