### PR TITLE
Use relative path to scapy layers directory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,8 @@ def get_layer_files_dst(sites, path="scapy_ssl_tls"):
             if os.path.isfile(layer_file_path):
                 layer_files.append(layer_file_path)
     for scapy_location in scapy_locations:
+        if scapy_location.startswith(sys.prefix):
+            scapy_location = scapy_location [len(sys.prefix):].lstrip(os.path.sep)
         data_files.append(
             (os.path.join(scapy_location, "layers"), layer_files))
     return data_files


### PR DESCRIPTION
Problem:

Scapy-ssl_tls/setup.py copies its layers to:
C:\Python27\Lib\site-packages\python27\lib\site-packages\scapy\layers
when wheel package is installed.

get_layer_files_dst() method returns list of tuples (<folder>, [<files>]), where <folder> is an absolute path. According to distutils documentation it should copy these files where we expect, but it does not work because wheel module does not support absolute paths, and they end up being installed relative to site-packages.

Solution:

Relative (to sys.prefix) path to scapy installation directory is used now.