### PR TITLE
Add missing os import

### DIFF
--- a/scapy_ssl_tls/ssl_tls.py
+++ b/scapy_ssl_tls/ssl_tls.py
@@ -2,6 +2,8 @@
 # -*- coding: UTF-8 -*-
 # Author : <github.com/tintinweb/scapy-ssl_tls>
 
+import os
+
 from scapy.packet import bind_layers, Packet, Raw
 from scapy.fields import *
 from scapy.layers.inet import TCP, UDP

--- a/setup.py
+++ b/setup.py
@@ -138,7 +138,7 @@ except (pkg_resources.DistributionNotFound, pkg_resources.VersionConflict):
 
 setup(
     name="scapy-ssl_tls",
-    version="2.0.0",
+    version="2.0.1",
     packages=["scapy_ssl_tls"],
     author="tintinweb",
     author_email="tintinweb@oststrom.com",
@@ -147,7 +147,7 @@ setup(
     license="GPLv2",
     keywords=["scapy", "ssl", "tls", "layer", "network", "dissect", "packets", "decrypt"],
     url="https://github.com/tintinweb/scapy-ssl_tls/",
-    download_url="https://github.com/tintinweb/scapy-ssl_tls/tarball/v2.0.0",
+    download_url="https://github.com/tintinweb/scapy-ssl_tls/tarball/v2.0.1",
     # generate rst from .md:  pandoc --from=markdown --to=rst README.md -o README.rst (fix diff section and footer)
     long_description=read("README.rst") if os.path.isfile("README.rst") else read("README.md"),
     install_requires=os_install_requires(),


### PR DESCRIPTION
Up to now `os` module was used from `scapy` instead direct import. In recent versions of `scapy` `os` module was removed from their scope and this in a result exposed missing import in `scapy_ssl_tls`.

Fixes #153